### PR TITLE
fix: deconstruct input before returning it

### DIFF
--- a/lib/run-test-result.ts
+++ b/lib/run-test-result.ts
@@ -48,7 +48,8 @@ export class RunTestResult {
         }
         const kvs = this.apifyClient.keyValueStore(this.run.defaultKeyValueStoreId);
         const input = await kvs.getRecord('INPUT');
-        return input as T;
+        this.input = input?.value;
+        return this.input as T;
     }
 
     getRunInfo = async (): Promise<ActorRun> => {


### PR DESCRIPTION
Closes #31 

I deconstruct the input from the `getRecord` result and also assign it to `this.input` property, like the other `getX` methods do.