### PR TITLE
Feat: pretty slack messages

### DIFF
--- a/bin/github.ts
+++ b/bin/github.ts
@@ -8,6 +8,7 @@ export const getPushData = async (path: string) => {
     const {
         commits: ghCommits,
         repository: { ssh_url: repoUrl, name },
+        head_commit: { author }
     } = event;
     const commits: Commit[] = ghCommits.map(({ author, message, id, timestamp }) => ({
         author: author.username,
@@ -24,6 +25,7 @@ export const getPushData = async (path: string) => {
         repoUrl,
         changelog,
         repository: name,
+        author: author.name
     };
 };
 

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -123,6 +123,7 @@ await yargs()
                 commits,
                 changelog,
                 repository,
+                author,
             } = await getPushData(args.pushEventPath);
             const isLatest = true;
             const actorConfigs = await getRepoActors();
@@ -148,6 +149,7 @@ await yargs()
                 changelog,
                 repository,
                 dryRun,
+                author
             });
         })
     .strictCommands()

--- a/bin/slack.ts
+++ b/bin/slack.ts
@@ -8,6 +8,7 @@ type NotifyToSlackOptions = {
     changelog: string | null
     commits: Commit[]
     dryRun: boolean
+    author: string
 }
 
 export const notifyToSlack = async ({
@@ -16,21 +17,23 @@ export const notifyToSlack = async ({
     changelog,
     repository,
     dryRun,
+    author
 }: NotifyToSlackOptions) => {
     const slack = new WebClient(getEnvVar('SLACK_TOKEN_RELEASES_BOT'));
 
     if (!changelog) {
-        console.warn('No new changelog entries found, haven\'t you forgotten to update it?');
+        console.warn('No new changelog entries found, did you forget to update it?');
     }
 
-    let shortMessage = `${repository}: new release:\n`;
+    let shortMessage = `${repository} --- New release (by ${author}):\n\n`;
 
     // This one is just for broader public that only cares about public facing changes
     if (changelog) {
-        console.error(`New changelog entries: ${changelog}`);
-        shortMessage += `Changelog:\n\n${changelog}\n`;
+        console.error(`=========================================`);
+        shortMessage += `**Additions to the changelog**:\n\n${changelog}\n`;
         const channel = '#delivery-public-actors';
-        console.error(`Sending slack message to channel: ${channel}. Message: ${shortMessage}`);
+        console.error(`**Sending slack message to channel**: ${channel}.\n\n${shortMessage}`);
+        console.error(`=========================================`);
         if (!dryRun) {
             await slack.chat.postMessage({
                 channel,
@@ -39,13 +42,15 @@ export const notifyToSlack = async ({
         }
     }
 
-    const commitsMessage = `${commits.map(({ author, message }, index) => `  ${index + 1} Commit message: ${message}\n  Author: ${author}.`).join('\n')}`;
-    const changedFilesMessage = `Files changed: ${changedFiles.join(', ')}`;
-    const longMessage = `${shortMessage}\nCommits:\n\n${commitsMessage}\n\n${changedFilesMessage}`;
+    const commitsMessage = `${commits.map(({ author, message }, index) => `${index + 1}. Commit message: ${message}\n\tAuthor: ${author}.`).join('\n')}`;
+    const changedFilesMessage = `**Files changed**: ${changedFiles.join(', ')}`;
+    const longMessage = `${shortMessage}\n**Commit list**:\n${commitsMessage}\n\n${changedFilesMessage}`;
 
     // This one is for devs and project managers that need to know more details
     const notifChannel = `#notif-${repository.toLowerCase()}`;
-    console.error(`Sending slack message to channel: ${notifChannel}. Message: ${longMessage}`);
+    console.error(`=========================================`);
+    console.error(`Sending slack message to channel: ${notifChannel}.\n\n${longMessage}`);
+    console.error(`=========================================`);
     if (!dryRun) {
         await slack.chat.postMessage({
             text: longMessage,

--- a/bin/test-report.ts
+++ b/bin/test-report.ts
@@ -35,7 +35,7 @@ export const reportTestRestuls = async ({
         }
     }
 
-    const failedAssertions: string[] = [];
+    const failedAssertions: { message: string; runLink: string }[] = [];
 
     console.error();
     console.error(`PASSED: ${passed.length}, FAILED: ${failed.length}`);
@@ -55,11 +55,11 @@ export const reportTestRestuls = async ({
     console.error('**************************************************');
     console.error();
     for (const [i, aResult] of failed.entries()) {
-        const { failureMessages, fullName } = aResult;
+        const { failureMessages, fullName, meta } = aResult;
         if (failureMessages) {
-            failedAssertions.push(...failureMessages.map(message => message.split('\n')?.[0]));
+            failedAssertions.push(...failureMessages.map(message => ({ message: message.split('\n')?.[0], runLink: meta.runLink })));
         }
-        console.error(`${i + 1}) ${fullName} ... ${aResult.meta.runLink}`);
+        console.error(`${i + 1}) ${fullName} ... ${meta.runLink}`);
         console.error();
     }
     console.error();
@@ -75,8 +75,8 @@ export const reportTestRestuls = async ({
     const jobLink = jobUrl ? ` Check <${jobUrl}|the job>.` : '';
     let slackMessage = `\`${workflowName ?? '-'}\`: *${repository ?? '-'}*`;
     slackMessage += `: has ${failedAssertions.length} failed assertions. Failing test suites: ${failed.length}/${total}.${jobLink}`;
-    slackMessage += `\n\n${failedAssertions[0]}`;
-    const blocks = failedAssertions.slice(1);
+    slackMessage += `\n\n${failedAssertions[0].message} --- ${failedAssertions[0].runLink}`;
+    const blocks = failedAssertions.slice(1).map(({ message, runLink }) => `• ${message} --- ${runLink}`);
 
     if (!repository) {
         console.error(`Repository not provided, not sending slack notification`);
@@ -87,7 +87,7 @@ export const reportTestRestuls = async ({
     const channel = `#notif-${repository.replace(/[^/]+\//, '')}`;
     console.error(`Sending a notification to slack channel ${channel}`);
     console.error('SLACK:', slackMessage);
-    console.error('  blocks:', blocks.join('\n'));
+    console.error('\tblocks:', blocks.join('\n\t\t'));
     if (!dryRun) {
         const slackToken = getEnvVar('SLACK_TOKEN_TESTS_BOT');
         await sendSlackMessage(channel, slackMessage, blocks, slackToken);

--- a/bin/test-report.ts
+++ b/bin/test-report.ts
@@ -35,7 +35,7 @@ export const reportTestRestuls = async ({
         }
     }
 
-    const failedAssertions: { message: string; runLink: string }[] = [];
+    const failedAssertions: { message: string; runLink: string, actorName: string }[] = [];
 
     console.error();
     console.error(`PASSED: ${passed.length}, FAILED: ${failed.length}`);
@@ -57,7 +57,7 @@ export const reportTestRestuls = async ({
     for (const [i, aResult] of failed.entries()) {
         const { failureMessages, fullName, meta } = aResult;
         if (failureMessages) {
-            failedAssertions.push(...failureMessages.map(message => ({ message: message.split('\n')?.[0], runLink: meta.runLink })));
+            failedAssertions.push(...failureMessages.map(message => ({ message: message.split('\n')?.[0], runLink: meta.runLink, actorName: meta.actorName })));
         }
         console.error(`${i + 1}) ${fullName} ... ${meta.runLink}`);
         console.error();
@@ -75,8 +75,8 @@ export const reportTestRestuls = async ({
     const jobLink = jobUrl ? ` Check <${jobUrl}|the job>.` : '';
     let slackMessage = `\`${workflowName ?? '-'}\`: *${repository ?? '-'}*`;
     slackMessage += `: has ${failedAssertions.length} failed assertions. Failing test suites: ${failed.length}/${total}.${jobLink}`;
-    slackMessage += `\n\n${failedAssertions[0].message} --- ${failedAssertions[0].runLink}`;
-    const blocks = failedAssertions.slice(1).map(({ message, runLink }) => `• ${message} --- ${runLink}`);
+    slackMessage += `\n\n${failedAssertions[0].message} --- <${failedAssertions[0].runLink}|${failedAssertions[0].actorName}>`;
+    const blocks = failedAssertions.slice(1).map(({ message, runLink, actorName }) => `• ${message} --- <${runLink}|${actorName}>`);
 
     if (!repository) {
         console.error(`Repository not provided, not sending slack notification`);
@@ -109,6 +109,7 @@ interface JsonAssertionResult {
     meta: {
         runId: string
         runLink: string
+        actorName: string
     }
     duration?: Milliseconds | null
     failureMessages: Array<string> | null

--- a/lib/extend-expect.ts
+++ b/lib/extend-expect.ts
@@ -117,6 +117,8 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                 ...userOptions,
             };
 
+            const failedAssertions: string[] = [];
+
             const diffs: Diffs = {
                 pass: true,
                 actual: ['Run:'],
@@ -125,9 +127,13 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
             {
                 const expected = options?.status;
                 const actual = received.status;
-                diffs.pass = expected === actual;
-                diffs.actual.push(`status=${actual}`);
-                diffs.expected.push(`status=${expected}`);
+                const statusTest = expected === actual;
+                if (statusTest === false) {
+                    diffs.pass = false;
+                    diffs.actual.push(`status=${actual}`);
+                    diffs.expected.push(`status=${expected}`);
+                    failedAssertions.push(`Failed status check.`);
+                }
             }
 
             const {
@@ -137,10 +143,19 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
             const datasetItemCount = (await received.getDataset()).items.length;
             const stats = (await received.getStatistics());
 
-            isWithinInterval(diffs, datasetItemCount, options, 'datasetItemCount');
-            isWithinInterval(diffs, durationMillis, options, 'duration');
+            const datasetItemCountTest = isWithinInterval(diffs, datasetItemCount, options, 'datasetItemCount');
+            if (datasetItemCountTest === false) {
+                failedAssertions.push(`Failed dataset item count check.`);
+            }
+            const durationTest = isWithinInterval(diffs, durationMillis, options, 'duration');
+            if (durationTest === false) {
+                failedAssertions.push(`Failed duration check.`);
+            }
             isWithinInterval(diffs, stats?.requestsFailed, options, 'failedRequests');
-            isWithinInterval(diffs, stats?.requestsRetries, options, 'requestsRetries');
+            const requestsRetriesTest = isWithinInterval(diffs, stats?.requestsRetries, options, 'requestsRetries');
+            if (requestsRetriesTest === false) {
+                failedAssertions.push(`Failed requests retries check.`);
+            }
 
             const ppeDiffs: Diffs = {
                 pass: true,
@@ -175,9 +190,12 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     isWithinInterval(ppeDiffs, actual[ppeEvent], expected, ppeEvent as PpeEvent);
                 }
 
-                diffs.pass = ppeDiffs.pass;
-                diffs.actual.push(ppeDiffs.actual.join('\n    '));
-                diffs.expected.push(ppeDiffs.expected.join('\n    '));
+                if (ppeDiffs.pass === false) {
+                    diffs.pass = ppeDiffs.pass;
+                    diffs.actual.push(ppeDiffs.actual.join('\n    '));
+                    diffs.expected.push(ppeDiffs.expected.join('\n    '));
+                    failedAssertions.push(`Failed PPE event counts check.`);
+                }
             }
 
             {
@@ -193,12 +211,13 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     diffs.pass = false;
                     diffs.actual.push(` logs=[${occuredLogs.join(', ')}]`);
                     diffs.expected.push(` logs=[]`);
+                    failedAssertions.push(`Failed forbidden logs check.`);
                 }
             }
 
             return {
                 pass: diffs.pass,
-                message: () => `Run ${received.id} didn't finish as expected`,
+                message: () => `Run did not finish as expected. Failed assertions: ${failedAssertions.join(' ',)}`,
                 actual: diffs.actual.join('\n  '),
                 expected: diffs.expected.join('\n  '),
             };
@@ -256,6 +275,7 @@ const isWithinInterval = <T extends string>(
             diffs.pass = false;
             diffs.actual.push(`${intervalOption}=${actual}`);
             diffs.expected.push(`${intervalOption}=${expected}`);
+            return false
         }
     } else if (typeof expected === 'object') {
         const { min, max } = expected;
@@ -263,6 +283,8 @@ const isWithinInterval = <T extends string>(
             diffs.pass = false;
             diffs.actual.push(`${intervalOption}=${actual}`);
             diffs.expected.push(`${intervalOption}=<${min ?? ''},${max ?? ''}>`);
+            return false
         }
     }
+    return
 };

--- a/lib/extend-expect.ts
+++ b/lib/extend-expect.ts
@@ -117,8 +117,6 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                 ...userOptions,
             };
 
-            const failedAssertions: string[] = [];
-
             const diffs: Diffs = {
                 pass: true,
                 actual: ['Run:'],
@@ -127,13 +125,9 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
             {
                 const expected = options?.status;
                 const actual = received.status;
-                const statusTest = expected === actual;
-                if (statusTest === false) {
-                    diffs.pass = false;
-                    diffs.actual.push(`status=${actual}`);
-                    diffs.expected.push(`status=${expected}`);
-                    failedAssertions.push(`Failed status check.`);
-                }
+                diffs.pass = expected === actual;
+                diffs.actual.push(`status=${actual}`);
+                diffs.expected.push(`status=${expected}`);
             }
 
             const {
@@ -143,19 +137,10 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
             const datasetItemCount = (await received.getDataset()).items.length;
             const stats = (await received.getStatistics());
 
-            const datasetItemCountTest = isWithinInterval(diffs, datasetItemCount, options, 'datasetItemCount');
-            if (datasetItemCountTest === false) {
-                failedAssertions.push(`Failed dataset item count check.`);
-            }
-            const durationTest = isWithinInterval(diffs, durationMillis, options, 'duration');
-            if (durationTest === false) {
-                failedAssertions.push(`Failed duration check.`);
-            }
+            isWithinInterval(diffs, datasetItemCount, options, 'datasetItemCount');
+            isWithinInterval(diffs, durationMillis, options, 'duration');
             isWithinInterval(diffs, stats?.requestsFailed, options, 'failedRequests');
-            const requestsRetriesTest = isWithinInterval(diffs, stats?.requestsRetries, options, 'requestsRetries');
-            if (requestsRetriesTest === false) {
-                failedAssertions.push(`Failed requests retries check.`);
-            }
+            isWithinInterval(diffs, stats?.requestsRetries, options, 'requestsRetries');
 
             const ppeDiffs: Diffs = {
                 pass: true,
@@ -190,12 +175,9 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     isWithinInterval(ppeDiffs, actual[ppeEvent], expected, ppeEvent as PpeEvent);
                 }
 
-                if (ppeDiffs.pass === false) {
-                    diffs.pass = ppeDiffs.pass;
-                    diffs.actual.push(ppeDiffs.actual.join('\n    '));
-                    diffs.expected.push(ppeDiffs.expected.join('\n    '));
-                    failedAssertions.push(`Failed PPE event counts check.`);
-                }
+                diffs.pass = ppeDiffs.pass;
+                diffs.actual.push(ppeDiffs.actual.join('\n    '));
+                diffs.expected.push(ppeDiffs.expected.join('\n    '));
             }
 
             {
@@ -211,13 +193,12 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     diffs.pass = false;
                     diffs.actual.push(` logs=[${occuredLogs.join(', ')}]`);
                     diffs.expected.push(` logs=[]`);
-                    failedAssertions.push(`Failed forbidden logs check.`);
                 }
             }
 
             return {
                 pass: diffs.pass,
-                message: () => `Run did not finish as expected. Failed assertions: ${failedAssertions.join(' ',)}`,
+                message: () => `Run ${received.id} didn't finish as expected`,
                 actual: diffs.actual.join('\n  '),
                 expected: diffs.expected.join('\n  '),
             };
@@ -275,7 +256,6 @@ const isWithinInterval = <T extends string>(
             diffs.pass = false;
             diffs.actual.push(`${intervalOption}=${actual}`);
             diffs.expected.push(`${intervalOption}=${expected}`);
-            return false
         }
     } else if (typeof expected === 'object') {
         const { min, max } = expected;
@@ -283,8 +263,6 @@ const isWithinInterval = <T extends string>(
             diffs.pass = false;
             diffs.actual.push(`${intervalOption}=${actual}`);
             diffs.expected.push(`${intervalOption}=<${min ?? ''},${max ?? ''}>`);
-            return false
         }
     }
-    return
 };

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -252,6 +252,7 @@ const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) =>
         task.meta = {
             runId: run.id,
             runLink,
+            actorName: actorNameOrId,
         };
 
         // waiting for datasetItemCount and chargedEventCounts to sync


### PR DESCRIPTION
Closes #19 
I've taken the liberty to do some changes on the `toFinishWith` matcher so that it tells something about what went wrong.

Some screenshots of how it looks:
Failed tests: 
<img width="1400" height="464" alt="Screenshot 2025-11-05 at 13 25 18" src="https://github.com/user-attachments/assets/3d2b2c4e-5a40-437a-8a0a-41b00a81778f" />
Markdown to be pushed on `notif-REPO`:
<img width="1339" height="243" alt="Screenshot 2025-11-05 at 13 29 24" src="https://github.com/user-attachments/assets/60d55181-7bc7-424a-a1ff-c3588ee761cc" />

Releases:
Logs:
<img width="1595" height="585" alt="Screenshot 2025-11-05 at 12 59 42" src="https://github.com/user-attachments/assets/55f588a8-9c50-4093-a747-690772660cce" />
Markdown to be pushed on Slack:
On `delivery-public-actors`:
<img width="1053" height="211" alt="Screenshot 2025-11-05 at 12 59 53" src="https://github.com/user-attachments/assets/fcf4f35e-d9f7-405c-a2d7-819876152c21" />
On `notif-REPO`:
<img width="1175" height="319" alt="Screenshot 2025-11-05 at 13 00 03" src="https://github.com/user-attachments/assets/7535aa5c-9754-411b-82c9-2125c7c06819" />


---

Updated:
Now tests on slack will link to the run and use the name of the actor as anchor text
<img width="1346" height="38" alt="Screenshot 2025-11-24 at 14 28 06" src="https://github.com/user-attachments/assets/e785073f-ef09-4487-b40c-bb2f6c9fcf9b" />
