### PR TITLE
feat: add maxRetriesPerRequest test

### DIFF
--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -12,4 +12,5 @@ export const TO_FINISH_WITH_OPTIONS: ToFinishWithOptionsWithDefaults = {
         'ReferenceError',
         'TypeError',
     ],
+    maxRetriesPerRequest: null,
 };

--- a/lib/extend-expect.ts
+++ b/lib/extend-expect.ts
@@ -196,6 +196,17 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                 }
             }
 
+            if (options.maxRetriesPerRequest !== null) {
+                const { maxRetriesPerRequest } = options;
+                const requestRetryHistogram = stats?.requestRetryHistogram || [];
+                const maxRetriesObserved = requestRetryHistogram.length;
+                if (maxRetriesObserved > maxRetriesPerRequest) {
+                    diffs.pass = false;
+                    diffs.actual.push(`maxRetriesPerRequest=${maxRetriesObserved - 1}`);
+                    diffs.expected.push(`maxRetriesPerRequest=${maxRetriesPerRequest}`);
+                }
+            }
+
             return {
                 pass: diffs.pass,
                 message: () => `Run ${received.id} didn't finish as expected`,

--- a/lib/extend-expect.ts
+++ b/lib/extend-expect.ts
@@ -198,11 +198,10 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
 
             if (options.maxRetriesPerRequest !== null) {
                 const { maxRetriesPerRequest } = options;
-                const requestRetryHistogram = stats?.requestRetryHistogram || [];
-                const maxRetriesObserved = requestRetryHistogram.length;
+                const maxRetriesObserved = (stats?.requestRetryHistogram ?? [0]).length - 1;
                 if (maxRetriesObserved > maxRetriesPerRequest) {
                     diffs.pass = false;
-                    diffs.actual.push(`maxRetriesPerRequest=${maxRetriesObserved - 1}`);
+                    diffs.actual.push(`maxRetriesPerRequest=${maxRetriesObserved}`);
                     diffs.expected.push(`maxRetriesPerRequest=${maxRetriesPerRequest}`);
                 }
             }

--- a/lib/extend-expect.ts
+++ b/lib/extend-expect.ts
@@ -145,7 +145,7 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
 
             const checkInterval = (
                 value: number | undefined,
-                key: ['datasetItemCount', 'duration', 'failedRequests', 'requestsRetries'][number],
+                key: ['datasetItemCount', 'duration', 'failedRequests', 'requestsRetries', 'maxRetriesPerRequest'][number],
                 label: string,
             ) => {
                 const result = isWithinInterval(diffs, value, options, key);
@@ -158,6 +158,8 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
             checkInterval(durationMillis, 'duration', 'duration');
             checkInterval(stats?.requestsFailed, 'failedRequests', 'failed requests');
             checkInterval(stats?.requestsRetries, 'requestsRetries', 'requests retries');
+            const maxRetriesObserved = (stats?.requestRetryHistogram ?? [0]).length - 1;
+            checkInterval(maxRetriesObserved, 'maxRetriesPerRequest', 'max retries per request');
 
             const ppeDiffs: Diffs = {
                 pass: true,
@@ -214,16 +216,6 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     diffs.actual.push(` logs=[${occuredLogs.join(', ')}]`);
                     diffs.expected.push(` logs=[]`);
                     failedAssertions.push(`Failed forbidden logs check, expected [] but got [${occuredLogs.join(', ')}].`);
-                }
-            }
-
-            if (options.maxRetriesPerRequest !== null) {
-                const { maxRetriesPerRequest } = options;
-                const maxRetriesObserved = (stats?.requestRetryHistogram ?? [0]).length - 1;
-                if (maxRetriesObserved > maxRetriesPerRequest) {
-                    diffs.pass = false;
-                    diffs.actual.push(`maxRetriesPerRequest=${maxRetriesObserved}`);
-                    diffs.expected.push(`maxRetriesPerRequest=${maxRetriesPerRequest}`);
                 }
             }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,6 +46,7 @@ export type ToFinishWithOptionsWithDefaults = {
     failedRequests: Interval | null
     requestsRetries: Interval | null
     forbiddenLogs: string[]
+    maxRetriesPerRequest: number | null
 }
 export type IntervalOption<PpeEvent extends string> = keyof Pick<
     ToFinishWithOptions<PpeEvent>,
@@ -123,6 +124,7 @@ export interface ActorMatchers<R = unknown> {
      * - `failedRequests` (default: `0`)
      * - `requestsRetries` (default: `{ max: 3 }`)
      * - `forbiddenLogs` (default: `['ReferenceError', 'TypeError']`)
+     * - `maxRetriesPerRequest` (not checked by default)
      * - `datasetItemCount` (required)
      * - `chargedEventCounts`
      */


### PR DESCRIPTION
Closes #37 

This is one feature I would like to add. It is optional to check because I can't figure out a way to generalize a maximum (but this is something that can be overcome if we allow overriding defaults with #35 )

@kazadoiyul since this repo doesn't allow multiple reviewer (can we fix this?)