### PR TITLE
docs: update retry count default value to 1

### DIFF
--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -5,10 +5,9 @@ import {
     TestFunction,
     test as vitestTest,
     SuiteFactory,
-    TestOptions,
     TestContext,
 } from 'vitest';
-import type { ActorBuild, RunOptions } from './types';
+import type { ActorBuild, ActorTestOptions, RunOptions } from './types';
 import { RunTestResult } from './run-test-result.js';
 import { extendExpect } from './extend-expect.js';
 import { getActorPrefilledInput, sleep } from './utils.js';
@@ -38,7 +37,7 @@ export { ExpectStatic };
 const { TESTER_APIFY_TOKEN, RUN_PLATFORM_TESTS, RUN_ALL_PLATFORM_TESTS } = process.env;
 const apifyClient = new ApifyClient({ token: TESTER_APIFY_TOKEN });
 
-const DEFAULT_TEST_OPTIONS: TestOptions = {
+const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
     // we want to run tests concurrently
     concurrent: true,
     // test should finish within 1 hour
@@ -48,12 +47,12 @@ const DEFAULT_TEST_OPTIONS: TestOptions = {
 export const describe = (
     name: string,
     fn?: SuiteFactory<object>,
-    options: TestOptions = DEFAULT_TEST_OPTIONS,
+    options: ActorTestOptions = DEFAULT_TEST_OPTIONS,
 ) => {
     vitestDescribe.runIf(!!RUN_PLATFORM_TESTS || !!RUN_ALL_PLATFORM_TESTS)(name, options, fn);
 };
 
-const DEFAULT_TEST_ACTOR_OPTIONS: TestOptions = {
+const DEFAULT_TEST_ACTOR_OPTIONS: ActorTestOptions = {
     retry: 1,
 };
 
@@ -61,7 +60,7 @@ export const testActor = <T>(
     actorName: string,
     testName: string,
     fn: TestFunction<{ run: ReturnType<typeof createStartRunFn<T>> }>,
-    testOptions?: TestOptions,
+    testOptions?: ActorTestOptions,
 ) => {
     const options = {
         ...DEFAULT_TEST_ACTOR_OPTIONS,
@@ -90,7 +89,7 @@ export const testStandbyActor = <I = any, O = any>(
     actorName: string,
     testName: string,
     fn: TestFunction<{ callStandby: ReturnType<typeof createStartStandbyFn<I, O>> }>,
-    testOptions?: TestOptions,
+    testOptions?: ActorTestOptions,
 ) => {
     const options = {
         ...DEFAULT_TEST_ACTOR_OPTIONS,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 import { ActorCallOptions } from 'apify-client';
-import { Assertion } from 'vitest';
+import { Assertion, TestOptions } from 'vitest';
 
 export type ActorBuild = {
     buildId: string;
@@ -130,6 +130,17 @@ export interface ActorMatchers<R = unknown> {
     toStartWith: (prefix: string) => R
     hard: <T>(actual: T, message?: string) => Assertion
 }
+
+export type ActorTestOptions = Omit<TestOptions, 'retry'> & {
+    /**
+     * Times to retry the test if fails. Useful for making flaky tests more stable.
+     * When retries is up, the last test error will be thrown.
+     *
+     * @default 1
+     */
+    // we are just extending the docs here to replace the default value, otherwise it's the exact same
+    retry?: TestOptions['retry'];
+};
 
 declare module 'vitest' {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Updates the JSDoc default value to 1, to reflect the actual value:
https://github.com/apify-projects/apify-test-tools/blob/d7e3a1ab2131a535d7bf4ece4e11cdf00544258b/lib/lib.ts#L56-L58

I got pretty confused by this 😭 A test was retrying for me because I didn't set `retry: 0` there, but the jsdoc was saying it should be 0, when in fact not 🙏 

---
Also, not sure about the reasoning behind the default value of 1 🤔 Personally I will set all my tests to 0, because tests should not be flaky, and if they are, you should know about it and fix it 🥀 