### PR TITLE
fix: change module resolution to nodenext and fix types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "printWidth": 120,
+    "tabWidth": 4,
+    "singleQuote": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/bin/git.ts
+++ b/bin/git.ts
@@ -1,9 +1,8 @@
-import { Commit, Config } from './types';
+import { Commit, Config } from './types.js';
 import { spawnCommandInGhWorkspace } from './utils.js';
 
 export const GIT_FORMAT_SEPARATOR = '»¦«';
 const GIT_LOG_FORMAT = ['%H', '%aN<%aE>', '%aD', '%s'].join(GIT_FORMAT_SEPARATOR);
-
 
 export const getBranchLastCommit = (branch: string): Commit => {
     const commitString = spawnCommandInGhWorkspace(`git log -1 --pretty=format:'${GIT_LOG_FORMAT}' ${branch}`);
@@ -12,17 +11,14 @@ export const getBranchLastCommit = (branch: string): Commit => {
 };
 
 export const getChangedFiles = (commits: Commit[]) => {
-    const changedFiles = commits.length === 1
-        ? spawnCommandInGhWorkspace(`git show --pretty='format:' --name-only ${commits[0].sha}`)
-        : spawnCommandInGhWorkspace(`git diff --name-only ${commits[0].sha}..${commits[commits.length - 1].sha}`);
+    const changedFiles =
+        commits.length === 1
+            ? spawnCommandInGhWorkspace(`git show --pretty='format:' --name-only ${commits[0].sha}`)
+            : spawnCommandInGhWorkspace(`git diff --name-only ${commits[0].sha}..${commits[commits.length - 1].sha}`);
     return changedFiles.split('\n');
 };
 
-export const getCommits = ({
-    sourceBranch,
-    targetBranch,
-    baseCommit: baseCommitSha,
-}: Config): Commit[] => {
+export const getCommits = ({ sourceBranch, targetBranch, baseCommit: baseCommitSha }: Config): Commit[] => {
     const targetBranchCommit = getBranchLastCommit(targetBranch);
     const sourceBranchCommit = getBranchLastCommit(sourceBranch);
     let baseCommit: Commit | undefined;
@@ -38,13 +34,12 @@ export const getCommits = ({
     // console.log(`git log --pretty=format:"${gitOutputFormat}" ${targetBranch}..${sourceBranch}`);
     // return [];
     const base = getBaseCommit(sourceBranchCommit, targetBranchCommit);
-    const commitsStrings = spawnCommandInGhWorkspace(`git log --pretty=format:'${GIT_LOG_FORMAT}' ${base.sha}..${sourceBranchCommit.sha}`)
-        .split('\n');
+    const commitsStrings = spawnCommandInGhWorkspace(
+        `git log --pretty=format:'${GIT_LOG_FORMAT}' ${base.sha}..${sourceBranchCommit.sha}`
+    ).split('\n');
     const commits = commitsStrings.map((commitString) => parseCommit(commitString)) as Commit[];
     commits.reverse();
-    const baseCommitIndex = baseCommit
-        ? commits.findIndex(({ sha }) => sha === baseCommit.sha)
-        : -1;
+    const baseCommitIndex = baseCommit ? commits.findIndex(({ sha }) => sha === baseCommit.sha) : -1;
     return commits.slice(baseCommitIndex + 1);
 };
 
@@ -72,4 +67,4 @@ export const parseCommit = (commitString: string): Commit => {
         date,
         message,
     };
-}
+};

--- a/bin/github.ts
+++ b/bin/github.ts
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { Commit, GitHubEventPush } from './types';
+import { Commit, GitHubEventPush } from './types.js';
 import { spawnCommandInGhWorkspace } from './utils.js';
 
 export const getPushData = async (path: string) => {
@@ -8,7 +8,7 @@ export const getPushData = async (path: string) => {
     const {
         commits: ghCommits,
         repository: { ssh_url: repoUrl, name },
-        head_commit: { author }
+        head_commit: { author },
     } = event;
     const commits: Commit[] = ghCommits.map(({ author, message, id, timestamp }) => ({
         author: author.username,
@@ -25,7 +25,7 @@ export const getPushData = async (path: string) => {
         repoUrl,
         changelog,
         repository: name,
-        author: author.name
+        author: author.name,
     };
 };
 
@@ -39,22 +39,13 @@ const getChangedFiles = ({ after, before }: GitHubEventPush): string[] => {
     return changedFiles.split('\n');
 };
 
-export const getChangelogChanges = (
-    changedFiles: string[],
-    event: GitHubEventPush,
-): string | null => {
+export const getChangelogChanges = (changedFiles: string[], event: GitHubEventPush): string | null => {
     const changelogPath = 'CHANGELOG.md';
     if (!changedFiles.includes(changelogPath)) {
         return null;
     }
     const { after, before } = event;
-    const diff = spawnCommandInGhWorkspace('git', [
-        'diff',
-        before,
-        after,
-        '--',
-        changelogPath,
-    ]);
+    const diff = spawnCommandInGhWorkspace('git', ['diff', before, after, '--', changelogPath]);
 
     const added: string[] = [];
     let startedChangelog = false;

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,15 +1,10 @@
 #!/usr/bin/env node
 
 import process from 'process';
-import yargs from 'yargs';
+import yargs, { type Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import {
-    getRepoActors,
-    getChangedActors,
-    spawnCommandInGhWorkspace,
-    setCwd,
-} from './utils.js';
+import { getRepoActors, getChangedActors, spawnCommandInGhWorkspace, setCwd } from './utils.js';
 import { runBuilds } from './build.js';
 import { getChangedFiles, getCommits } from './git.js';
 import { getPushData } from './github.js';
@@ -21,7 +16,7 @@ import { reportTestRestuls } from './test-report.js';
  */
 const middlewares = [setCwd];
 
-const buildOptions = (y: yargs.Argv) => {
+const buildOptions = (y: Argv) => {
     return y
         .option('target-branch', {
             type: 'string',
@@ -33,7 +28,7 @@ const buildOptions = (y: yargs.Argv) => {
         })
         .option('base-commit', {
             type: 'string',
-        })
+        });
 };
 
 await yargs()
@@ -61,10 +56,15 @@ await yargs()
         const changedFiles = getChangedFiles(commits);
         console.log(JSON.stringify(changedFiles));
     })
-    .command('get-actor-configs', '', (_) => _, async () => {
-        const actorConfigs = await getRepoActors();
-        console.log(JSON.stringify(actorConfigs));
-    })
+    .command(
+        'get-actor-configs',
+        '',
+        (_) => _,
+        async () => {
+            const actorConfigs = await getRepoActors();
+            console.log(JSON.stringify(actorConfigs));
+        }
+    )
     .command('get-affected-actors', '', buildOptions, async (args) => {
         const commits = getCommits(args);
         const changedFiles = getChangedFiles(commits);
@@ -75,19 +75,20 @@ await yargs()
     .command(
         'report-tests',
         '',
-        (args) => args
-            .option('report-file', { type: 'string', demandOption: true })
-            .option('job-url', { type: 'string' })
-            .option('workflow-name', { type: 'string' })
-            .option('repository', { type: 'string' }),
+        (args) =>
+            args
+                .option('report-file', { type: 'string', demandOption: true })
+                .option('job-url', { type: 'string' })
+                .option('workflow-name', { type: 'string' })
+                .option('repository', { type: 'string' }),
         async (args) => {
             await reportTestRestuls(args);
-        })
+        }
+    )
     .command(
         'build',
         '',
-        (args) => buildOptions(args)
-            .option('dry-run', { type: 'boolean', default: false }),
+        (args) => buildOptions(args).option('dry-run', { type: 'boolean', default: false }),
         async (args) => {
             const commits = getCommits(args);
             const changedFiles = getChangedFiles(commits);
@@ -98,8 +99,10 @@ await yargs()
             });
             // https://github.com/apify-store/google-maps#:actors/lukaskrivka_google-maps-with-contact-details
             // git@github.com:apify-store/google-maps#:actors/lukaskrivka_google-maps-with-contact-details
-            const repoUrl = spawnCommandInGhWorkspace(`git remote get-url origin`)
-                .replace(/^https:\/\/github\.com\//, 'git@github.com:');
+            const repoUrl = spawnCommandInGhWorkspace(`git remote get-url origin`).replace(
+                /^https:\/\/github\.com\//,
+                'git@github.com:'
+            );
 
             const builds = await runBuilds({
                 repoUrl,
@@ -108,23 +111,19 @@ await yargs()
                 dryRun: args.dryRun,
             });
             console.log(JSON.stringify(builds));
-        })
+        }
+    )
     .command(
         'release',
         '',
-        (args) => args
-            .option('push-event-path', { type: 'string', demandOption: true })
-            .option('dry-run', { type: 'boolean', default: false }),
+        (args) =>
+            args
+                .option('push-event-path', { type: 'string', demandOption: true })
+                .option('dry-run', { type: 'boolean', default: false }),
         async (args) => {
-            const {
-                branch,
-                changedFiles,
-                repoUrl,
-                commits,
-                changelog,
-                repository,
-                author,
-            } = await getPushData(args.pushEventPath);
+            const { branch, changedFiles, repoUrl, commits, changelog, repository, author } = await getPushData(
+                args.pushEventPath
+            );
             const isLatest = true;
             const actorConfigs = await getRepoActors();
             const { actorsChanged } = getChangedActors({
@@ -149,9 +148,10 @@ await yargs()
                 changelog,
                 repository,
                 dryRun,
-                author
+                author,
             });
-        })
+        }
+    )
     .strictCommands()
     .demandCommand(1, 'Command is required')
     .parse(hideBin(process.argv));

--- a/bin/slack.ts
+++ b/bin/slack.ts
@@ -1,15 +1,15 @@
 import { WebClient } from '@slack/web-api';
-import { Commit } from './types';
+import { Commit } from './types.js';
 import { getEnvVar } from './utils.js';
 
 type NotifyToSlackOptions = {
-    repository: string
-    changedFiles: string[]
-    changelog: string | null
-    commits: Commit[]
-    dryRun: boolean
-    author: string
-}
+    repository: string;
+    changedFiles: string[];
+    changelog: string | null;
+    commits: Commit[];
+    dryRun: boolean;
+    author: string;
+};
 
 export const notifyToSlack = async ({
     changedFiles,
@@ -17,7 +17,7 @@ export const notifyToSlack = async ({
     changelog,
     repository,
     dryRun,
-    author
+    author,
 }: NotifyToSlackOptions) => {
     const slack = new WebClient(getEnvVar('SLACK_TOKEN_RELEASES_BOT'));
 
@@ -42,7 +42,9 @@ export const notifyToSlack = async ({
         }
     }
 
-    const commitsMessage = `${commits.map(({ author, message }, index) => `${index + 1}. Commit message: ${message}\n\tAuthor: ${author}.`).join('\n')}`;
+    const commitsMessage = `${commits
+        .map(({ author, message }, index) => `${index + 1}. Commit message: ${message}\n\tAuthor: ${author}.`)
+        .join('\n')}`;
     const changedFilesMessage = `**Files changed**: ${changedFiles.join(', ')}`;
     const longMessage = `${shortMessage}\n**Commit list**:\n${commitsMessage}\n\n${changedFilesMessage}`;
 
@@ -59,12 +61,7 @@ export const notifyToSlack = async ({
     }
 };
 
-export const sendSlackMessage = async (
-    channel: string,
-    text: string,
-    blocks: string[],
-    token: string,
-) => {
+export const sendSlackMessage = async (channel: string, text: string, blocks: string[], token: string) => {
     const slack = new WebClient(token);
     const { ts } = await slack.chat.postMessage({ text, channel });
     if (blocks.length > 0 && ts) {

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -1,4 +1,4 @@
-import type { ToFinishWithOptionsWithDefaults } from './types';
+import type { ToFinishWithOptionsWithDefaults } from './types.js';
 
 export const TO_FINISH_WITH_OPTIONS: ToFinishWithOptionsWithDefaults = {
     status: 'SUCCEEDED',
@@ -8,9 +8,6 @@ export const TO_FINISH_WITH_OPTIONS: ToFinishWithOptionsWithDefaults = {
     },
     failedRequests: 0,
     requestsRetries: { max: 3 },
-    forbiddenLogs: [
-        'ReferenceError',
-        'TypeError',
-    ],
     maxRetriesPerRequest: null,
+    forbiddenLogs: ['ReferenceError', 'TypeError'],
 };

--- a/lib/extend-expect.ts
+++ b/lib/extend-expect.ts
@@ -1,7 +1,7 @@
 import type { Assertion, ExpectStatic } from 'vitest';
 
 import { TO_FINISH_WITH_OPTIONS } from './consts.js';
-import type { Interval, ToFinishWithOptions } from './types';
+import type { Interval, ToFinishWithOptions } from './types.js';
 import { RunTestResult } from './run-test-result.js';
 
 export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
@@ -110,7 +110,7 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
         },
         toFinishWith: async <PpeEvent extends string>(
             received: RunTestResult,
-            userOptions: ToFinishWithOptions<PpeEvent>,
+            userOptions: ToFinishWithOptions<PpeEvent>
         ) => {
             const options = {
                 ...TO_FINISH_WITH_OPTIONS,
@@ -146,11 +146,13 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
             const checkInterval = (
                 value: number | undefined,
                 key: ['datasetItemCount', 'duration', 'failedRequests', 'requestsRetries'][number],
-                label: string,
+                label: string
             ) => {
                 const result = isWithinInterval(diffs, value, options, key);
                 if (result === false) {
-                    failedAssertions.push(`Failed ${label} check, expected ${JSON.stringify(options[key])}, got ${value}.`);
+                    failedAssertions.push(
+                        `Failed ${label} check, expected ${JSON.stringify(options[key])}, got ${value}.`
+                    );
                 }
             };
 
@@ -166,7 +168,9 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                         diffs.pass = false;
                         diffs.actual.push(`maxRetriesPerRequest=${maxRetriesPerRequestObserved}`);
                         diffs.expected.push(`maxRetriesPerRequest<=${options.maxRetriesPerRequest}`);
-                        failedAssertions.push(`Failed max retries observed check, expected <=${options.maxRetriesPerRequest}, got ${maxRetriesPerRequestObserved}.`);
+                        failedAssertions.push(
+                            `Failed max retries observed check, expected <=${options.maxRetriesPerRequest}, got ${maxRetriesPerRequestObserved}.`
+                        );
                     }
                 }
             }
@@ -186,12 +190,7 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
 
                 for (const ppeEvent of uniquePpeEvents) {
                     if (!(ppeEvent in expected)) {
-                        isWithinInterval(
-                            ppeDiffs,
-                            actual[ppeEvent],
-                            { [ppeEvent]: 0 },
-                            ppeEvent,
-                        );
+                        isWithinInterval(ppeDiffs, actual[ppeEvent], { [ppeEvent]: 0 }, ppeEvent);
                         continue;
                     }
                     if (!(ppeEvent in actual)) {
@@ -207,7 +206,11 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     diffs.pass = ppeDiffs.pass;
                     diffs.actual.push(ppeDiffs.actual.join('\n    '));
                     diffs.expected.push(ppeDiffs.expected.join('\n    '));
-                    failedAssertions.push(`Failed PPE event counts check, expected ${JSON.stringify(options.chargedEventCounts)}, got ${JSON.stringify(chargedEventCounts)}.`);
+                    failedAssertions.push(
+                        `Failed PPE event counts check, expected ${JSON.stringify(
+                            options.chargedEventCounts
+                        )}, got ${JSON.stringify(chargedEventCounts)}.`
+                    );
                 }
             }
 
@@ -224,13 +227,15 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
                     diffs.pass = false;
                     diffs.actual.push(` logs=[${occuredLogs.join(', ')}]`);
                     diffs.expected.push(` logs=[]`);
-                    failedAssertions.push(`Failed forbidden logs check, expected [] but got [${occuredLogs.join(', ')}].`);
+                    failedAssertions.push(
+                        `Failed forbidden logs check, expected [] but got [${occuredLogs.join(', ')}].`
+                    );
                 }
             }
 
             return {
                 pass: diffs.pass,
-                message: () => `Run did not finish as expected. Failed assertions: ${failedAssertions.join(' ',)}`,
+                message: () => `Run did not finish as expected. Failed assertions: ${failedAssertions.join(' ')}`,
                 actual: diffs.actual.join('\n  '),
                 expected: diffs.expected.join('\n  '),
             };
@@ -266,17 +271,16 @@ export const extendExpect = (expect: ExpectStatic): ExpectStatic => {
 };
 
 type Diffs = {
-    pass: boolean
-    actual: string[]
-    expected: string[]
-
-}
+    pass: boolean;
+    actual: string[];
+    expected: string[];
+};
 
 const isWithinInterval = <T extends string>(
     diffs: Diffs,
     actual: number | undefined,
     options: Record<T, Interval | null>,
-    intervalOption: T,
+    intervalOption: T
 ) => {
     const expected = options[intervalOption];
     if (expected === null) {
@@ -288,7 +292,7 @@ const isWithinInterval = <T extends string>(
             diffs.pass = false;
             diffs.actual.push(`${intervalOption}=${actual}`);
             diffs.expected.push(`${intervalOption}=${expected}`);
-            return false
+            return false;
         }
     } else if (typeof expected === 'object') {
         const { min, max } = expected;
@@ -296,8 +300,8 @@ const isWithinInterval = <T extends string>(
             diffs.pass = false;
             diffs.actual.push(`${intervalOption}=${actual}`);
             diffs.expected.push(`${intervalOption}=<${min ?? ''},${max ?? ''}>`);
-            return false
+            return false;
         }
     }
-    return
+    return;
 };

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -7,7 +7,7 @@ import {
     SuiteFactory,
     TestContext,
 } from 'vitest';
-import type { ActorBuild, ActorTestOptions, RunOptions } from './types';
+import type { ActorBuild, ActorTestOptions, RunOptions } from './types.js';
 import { RunTestResult } from './run-test-result.js';
 import { extendExpect } from './extend-expect.js';
 import { getActorPrefilledInput, sleep } from './utils.js';
@@ -26,7 +26,7 @@ try {
     throw new Error(`Failed to parse actor builds: ${err}`);
 }
 
-const config = actorBuilds.reduce((map, cfg) => {
+const config = actorBuilds.reduce<Map<string, ActorBuild>>((map, cfg) => {
     map.set(cfg.actorName, cfg);
     map.set(cfg.actorId, cfg);
     return map;
@@ -44,11 +44,7 @@ const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
     timeout: 60_000 * 60,
 };
 
-export const describe = (
-    name: string,
-    fn?: SuiteFactory<object>,
-    options: ActorTestOptions = DEFAULT_TEST_OPTIONS,
-) => {
+export const describe = (name: string, fn?: SuiteFactory<object>, options: ActorTestOptions = DEFAULT_TEST_OPTIONS) => {
     vitestDescribe.runIf(!!RUN_PLATFORM_TESTS || !!RUN_ALL_PLATFORM_TESTS)(name, options, fn);
 };
 
@@ -60,7 +56,7 @@ export const testActor = <T>(
     actorName: string,
     testName: string,
     fn: TestFunction<{ run: ReturnType<typeof createStartRunFn<T>> }>,
-    testOptions?: ActorTestOptions,
+    testOptions?: ActorTestOptions
 ) => {
     const options = {
         ...DEFAULT_TEST_ACTOR_OPTIONS,
@@ -68,8 +64,7 @@ export const testActor = <T>(
     };
     const name = `${actorName}: ${testName}`;
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorName);
-
-    vitestTest.runIf(shouldRun)(name, options, async (context) => {
+    vitestTest.runIf(shouldRun)(name, options, async <T extends TestContext>(context: T) => {
         const { expect, ...rest } = context;
         await fn({
             expect: extendExpect(expect),
@@ -89,7 +84,7 @@ export const testStandbyActor = <I = any, O = any>(
     actorName: string,
     testName: string,
     fn: TestFunction<{ callStandby: ReturnType<typeof createStartStandbyFn<I, O>> }>,
-    testOptions?: ActorTestOptions,
+    testOptions?: ActorTestOptions
 ) => {
     const options = {
         ...DEFAULT_TEST_ACTOR_OPTIONS,
@@ -98,7 +93,7 @@ export const testStandbyActor = <I = any, O = any>(
     const name = `${actorName}: ${testName}`;
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorName);
 
-    vitestTest.runIf(shouldRun)(name, options, async (context) => {
+    vitestTest.runIf(shouldRun)(name, options, async <T extends TestContext>(context: T) => {
         const standbyTask = await createStandbyTask(actorName, config.get(actorName)?.buildNumber);
         const { annotate } = context;
         const { expect, ...rest } = context;
@@ -113,29 +108,28 @@ export const testStandbyActor = <I = any, O = any>(
         } catch {}
 
         const { taskId } = standbyTask;
-        const runs = (await apifyClient.task(taskId).runs().list()).items
+        const runs = (await apifyClient.task(taskId).runs().list()).items;
         for (const run of runs) {
             const runLink = generateRunLink(run);
             await annotate(runLink, 'run_link');
         }
 
         if (taskId) {
-            await apifyClient.task(taskId).delete()
+            await apifyClient.task(taskId).delete();
         }
-
     });
 };
 
 export const testTestActor = <T>(
     testName: string,
-    fn: TestFunction<{ run: ReturnType<typeof createStartRunFn<T>> }>,
+    fn: TestFunction<{ run: ReturnType<typeof createStartRunFn<T>> }>
 ) => {
     vitestTest(testName, async (context) => {
         const { expect, ...rest } = context;
         await fn({
             expect: extendExpect(expect),
             // @ts-expect-error: this just to test custom matchers
-            run: () => { },
+            run: () => {},
             ...rest,
         });
     });
@@ -158,14 +152,14 @@ const createStartStandbyFn = <I, O>(standbyTask: StandbyTask) => {
             body: JSON.stringify(input),
         });
 
-        const data = await response.json() as O;
+        const data = (await response.json()) as O;
         return {
             data,
             status: response.status,
             headers: response.headers,
         };
     };
-}
+};
 
 interface StandbyTask {
     standbyUrl: string;
@@ -174,7 +168,7 @@ interface StandbyTask {
 
 const randomInt = (min: number, max: number) => {
     return Math.floor(Math.random() * (max - min + 1)) + min;
-}
+};
 
 /**
  * Creates a task with specific `build` - either `buildNumber` or default.
@@ -202,19 +196,22 @@ const createStandbyTask = async (actorNameOrId: string, buildNumber?: string): P
     const actorStandbyOptions: ActorStandby = {
         ...defaultActorStandby,
         build,
-    }
+    };
 
     try {
         const title = `Test task - ${build}:${actorNameOrId}`.slice(0, 62);
         // we try to create unique task name containing only `a-z0-9-` characters and at most 63 characters long
-        const name = `${randomInt(1, 1_000_000)}${title.toLowerCase().replaceAll(/\s+/g, '').replaceAll(/[^a-z0-9-]+/g, '-')}`.slice(0, 62);
-        const newTask = await apifyClient.tasks().create({
+        const name = `${randomInt(1, 1_000_000)}${title
+            .toLowerCase()
+            .replaceAll(/\s+/g, '')
+            .replaceAll(/[^a-z0-9-]+/g, '-')}`.slice(0, 62);
+        const newTask = (await apifyClient.tasks().create({
             actId: actorNameOrId,
             actorStandby: actorStandbyOptions,
             description: `Task for testing standby version ${build}`,
             title,
             name,
-        }) as Task & { standbyUrl?: string };
+        })) as Task & { standbyUrl?: string };
 
         const { id, standbyUrl } = newTask;
 
@@ -225,11 +222,11 @@ const createStandbyTask = async (actorNameOrId: string, buildNumber?: string): P
         return {
             standbyUrl,
             taskId: id,
-        }
+        };
     } catch (error) {
         throw new Error(`Failed to create task: ${error}`);
     }
-}
+};
 
 const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) => {
     const { annotate, task } = testContext;
@@ -237,31 +234,23 @@ const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) =>
     const build = actorConfig?.buildNumber;
     const buildId = actorConfig?.buildId;
     return async (runOptions: RunOptions<T>) => {
-        const {
-            input,
-            options,
-            prefilledInput,
-            runId,
-        } = runOptions;
+        const { input, options, prefilledInput, runId } = runOptions;
 
         if (runId) {
-            const run = await apifyClient.run(runId).get()
+            const run = await apifyClient.run(runId).get();
             if (!run) {
                 throw new Error(`Run with id "${runId}" doesn't exist`);
             }
-            return new RunTestResult(apifyClient, run)
+            return new RunTestResult(apifyClient, run);
         }
 
         const actor = apifyClient.actor(actorNameOrId);
 
         const actorInput = {
-            ...(prefilledInput && await getActorPrefilledInput(apifyClient, actorNameOrId, buildId)),
+            ...(prefilledInput && (await getActorPrefilledInput(apifyClient, actorNameOrId, buildId))),
             ...input,
         };
-        const run = await actor.call(
-            actorInput,
-            { build, ...options, },
-        );
+        const run = await actor.call(actorInput, { build, ...options });
 
         const runLink = generateRunLink(run);
         await annotate(runLink, 'run_link');
@@ -281,4 +270,4 @@ const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) =>
 
 const generateRunLink = (run: ActorRun | ActorRunListItem): string => {
     return `https://console.apify.com/view/runs/${run.id}`;
-}
+};

--- a/lib/run-test-result.ts
+++ b/lib/run-test-result.ts
@@ -1,5 +1,5 @@
 import { ActorRun, ApifyClient, KeyValueStoreClient } from 'apify-client';
-import type { Dataset, SdkCrawlerStatistics } from './types';
+import type { Dataset, SdkCrawlerStatistics } from './types.js';
 
 export class RunTestResult {
     private log: string | undefined;
@@ -9,10 +9,9 @@ export class RunTestResult {
     private runInfo: ActorRun | undefined;
     private input: unknown | undefined;
 
-    constructor(
-        private readonly apifyClient: ApifyClient,
-        private readonly run: ActorRun,
-    ) { /**/ }
+    constructor(private readonly apifyClient: ApifyClient, private readonly run: ActorRun) {
+        /**/
+    }
 
     getStatistics = async (): Promise<SdkCrawlerStatistics | undefined> => {
         if (this.statistics) {
@@ -33,7 +32,7 @@ export class RunTestResult {
         return runLog as string;
     };
 
-    getDataset = async<T>(): Promise<Dataset<T>> => {
+    getDataset = async <T>(): Promise<Dataset<T>> => {
         if (this.dataset) {
             return this.dataset as Dataset<T>;
         }
@@ -49,18 +48,18 @@ export class RunTestResult {
         }
         const keyValueStoreClient = this.apifyClient.keyValueStore(this.run.defaultKeyValueStoreId);
         this.keyValueStoreClient = keyValueStoreClient;
-        return keyValueStoreClient
+        return keyValueStoreClient;
     };
 
-    getInput = async<T>(): Promise<T> => {
+    getInput = async <T>(): Promise<T> => {
         if (this.input) {
-            return this.input as T
+            return this.input as T;
         }
         const kvs = this.apifyClient.keyValueStore(this.run.defaultKeyValueStoreId);
         const input = await kvs.getRecord('INPUT');
         this.input = input?.value;
         return this.input as T;
-    }
+    };
 
     getRunInfo = async (): Promise<ActorRun> => {
         if (this.runInfo) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,58 +6,57 @@ export type ActorBuild = {
     actorId: string;
     buildNumber: string;
     actorName: string;
-}
+};
 
 export type RunOptions<T> = {
-    input: Omit<T, 'actorName'>
-    options?: ActorCallOptions
-    prefilledInput?: boolean
+    input: Omit<T, 'actorName'>;
+    options?: ActorCallOptions;
+    prefilledInput?: boolean;
     /**
      * If you specify `runId`, all the other options will be ignored and this run's data will
      * be downloaded instead.
      *
      * This is usefull for testing your tests on existing runs
      */
-    runId?: string
-}
+    runId?: string;
+};
 
 export type Dataset<T> = {
-    items: T[]
-}
+    items: T[];
+};
 
-export type OpenInterval = {
-    min: number
-    max?: undefined
-} | {
-    min?: undefined
-    max: number
-}
+export type OpenInterval =
+    | {
+          min: number;
+          max?: undefined;
+      }
+    | {
+          min?: undefined;
+          max: number;
+      };
 
 export type ClosedInterval = {
-    min: number
-    max: number
-}
+    min: number;
+    max: number;
+};
 
-export type Interval = number | OpenInterval | ClosedInterval
+export type Interval = number | OpenInterval | ClosedInterval;
 
 export type ToFinishWithOptionsWithDefaults = {
-    status: RunStatus
-    duration: Interval | null
-    failedRequests: Interval | null
-    requestsRetries: Interval | null
-    forbiddenLogs: string[]
-    maxRetriesPerRequest: number | null
-}
+    status: RunStatus;
+    duration: Interval | null;
+    failedRequests: Interval | null;
+    requestsRetries: Interval | null;
+    forbiddenLogs: string[];
+    maxRetriesPerRequest: number | null;
+};
 export type IntervalOption<PpeEvent extends string> = keyof Pick<
     ToFinishWithOptions<PpeEvent>,
-    | 'datasetItemCount'
-    | 'requestsRetries'
-    | 'failedRequests'
-    | 'duration'
->
+    'datasetItemCount' | 'requestsRetries' | 'failedRequests' | 'duration'
+>;
 
 export type ToFinishWithOptions<PpeEvent extends string> = Partial<ToFinishWithOptionsWithDefaults> & {
-    datasetItemCount: Interval
+    datasetItemCount: Interval;
     /**
      * Define expected charged (PPE) event counts. You can also define count as `Interval`.
      *
@@ -72,26 +71,26 @@ export type ToFinishWithOptions<PpeEvent extends string> = Partial<ToFinishWithO
      * If you omit any PPE event, it's expected count will be 0.
      * Assertion will fail if `chargedEventCounts` doesn't contain some of the expected events.
      */
-    chargedEventCounts?: Record<PpeEvent, Interval>
+    chargedEventCounts?: Record<PpeEvent, Interval>;
 };
 
 export type SdkCrawlerStatistics = {
-    requestsFinished: number
-    requestsFailed: number
-    requestsRetries: number
-    requestsFailedPerMinute: number
-    requestsFinishedPerMinute: number
-    requestMinDurationMillis: number
-    requestMaxDurationMillis: number
-    requestRetryHistogram: number[]
-    requestTotalFailedDurationMillis: number
-    requestTotalFinishedDurationMillis: number
-    crawlerStartedAt: string
-    crawlerFinishedAt: string
-    statsPersistedAt: string
-    crawlerRuntimeMillis: number
-    crawlerLastStartTimestamp: number
-}
+    requestsFinished: number;
+    requestsFailed: number;
+    requestsRetries: number;
+    requestsFailedPerMinute: number;
+    requestsFinishedPerMinute: number;
+    requestMinDurationMillis: number;
+    requestMaxDurationMillis: number;
+    requestRetryHistogram: number[];
+    requestTotalFailedDurationMillis: number;
+    requestTotalFinishedDurationMillis: number;
+    crawlerStartedAt: string;
+    crawlerFinishedAt: string;
+    statsPersistedAt: string;
+    crawlerRuntimeMillis: number;
+    crawlerLastStartTimestamp: number;
+};
 
 export type RunStatus =
     | 'SUCCEEDED'
@@ -101,22 +100,22 @@ export type RunStatus =
     | 'ABORTING'
     | 'ABORTED'
     | 'TIMING-OUT'
-    | 'TIMED-OUT'
+    | 'TIMED-OUT';
 
 export interface ActorMatchers<R = unknown> {
-    toBeArray: () => R
-    toBeBoolean: () => R
-    toBeEmptyArray: () => R
-    toBeNonEmptyArray: () => R
-    toBeNonEmptyString: () => R
-    toBeNumber: () => R
-    toBeFalse: () => R
-    toBeTrue: () => R
-    toBeNonEmptyObject: () => R
-    toBeObject: () => R
-    toBeString: () => R
-    toBeWholeNumber: () => R
-    toBeWithinRange: (lower: number, upper: number) => R
+    toBeArray: () => R;
+    toBeBoolean: () => R;
+    toBeEmptyArray: () => R;
+    toBeNonEmptyArray: () => R;
+    toBeNonEmptyString: () => R;
+    toBeNumber: () => R;
+    toBeFalse: () => R;
+    toBeTrue: () => R;
+    toBeNonEmptyObject: () => R;
+    toBeObject: () => R;
+    toBeString: () => R;
+    toBeWholeNumber: () => R;
+    toBeWithinRange: (lower: number, upper: number) => R;
     /**
      * Validates the following properties of a run:
      * - `status` (default: `SUCCEEDED`)
@@ -128,9 +127,9 @@ export interface ActorMatchers<R = unknown> {
      * - `datasetItemCount` (required)
      * - `chargedEventCounts`
      */
-    toFinishWith: <PpeEvent extends string>(options: ToFinishWithOptions<PpeEvent>) => Promise<R>
-    toStartWith: (prefix: string) => R
-    hard: <T>(actual: T, message?: string) => Assertion
+    toFinishWith: <PpeEvent extends string>(options: ToFinishWithOptions<PpeEvent>) => Promise<R>;
+    toStartWith: (prefix: string) => R;
+    hard: <T>(actual: T, message?: string) => Assertion;
 }
 
 export type ActorTestOptions = Omit<TestOptions, 'retry'> & {
@@ -146,6 +145,8 @@ export type ActorTestOptions = Omit<TestOptions, 'retry'> & {
 
 declare module 'vitest' {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    interface Assertion<T = any> extends ActorMatchers<T> { }
-    interface AsymmetricMatchersContaining extends ActorMatchers { }
+    interface Assertion<T = any> extends ActorMatchers<T> {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    interface Matchers<T = any> extends ActorMatchers<T> {}
+    interface AsymmetricMatchersContaining extends ActorMatchers {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "vitest": ">=3.2.4"
             }
         },
         "node_modules/@apify/consts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
         "typescript": "^5.7",
         "vitest": "^3.2.4"
     },
+    "peerDependencies": {
+        "vitest": ">=3.2.4"
+    },
     "scripts": {
         "start": "npm run dist/bin/main.js",
         "start:dev": "GITHUB_WORKSPACE=local-clone tsx bin/main.ts",

--- a/test/unit/custom-matchers.test.ts
+++ b/test/unit/custom-matchers.test.ts
@@ -2,13 +2,10 @@ import process from 'process';
 import { describe } from 'vitest';
 
 import { ApifyClient } from 'apify-client';
-import { testStandbyActor, testTestActor } from '../../lib/lib';
-import { RunTestResult } from '../../lib/run-test-result';
+import { testStandbyActor, testTestActor } from '../../lib/lib.js';
+import { RunTestResult } from '../../lib/run-test-result.js';
 
-type PpeEventType =
-    | 'actor-start'
-    | 'search-page-scraped'
-    | 'ads-scraped'
+type PpeEventType = 'actor-start' | 'search-page-scraped' | 'ads-scraped';
 enum PpeEventEnum {
     ACTOR_START = 'actor-start',
     SEARCH_PAGE_SCRAPED = 'search-page-scraped',
@@ -45,7 +42,7 @@ describe('custom-matchers', { timeout: 100_000 }, () => {
             },
         });
 
-        await expect(runResult).toFinishWith<typeof PPE_EVENT_CONST[keyof typeof PPE_EVENT_CONST]>({
+        await expect(runResult).toFinishWith<(typeof PPE_EVENT_CONST)[keyof typeof PPE_EVENT_CONST]>({
             datasetItemCount: { min: 1, max: 20 },
             chargedEventCounts: {
                 'actor-start': 1,
@@ -67,7 +64,7 @@ describe('custom-matchers', { timeout: 100_000 }, () => {
                     maxRequests: 3,
                     aggregateContacts: true,
                 },
-            })
+            });
             expect(status).toBe(200);
             expect(data[0].domain).toEqual('apify.com');
         }
@@ -78,7 +75,7 @@ describe('custom-matchers', { timeout: 100_000 }, () => {
                 maxRequests: 3,
                 aggregateContacts: true,
             },
-        })
+        });
         expect(status).toBe(200);
         expect(data[0].domain).toEqual('apify.com');
     });

--- a/test/unit/parse-commit.test.ts
+++ b/test/unit/parse-commit.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { GIT_FORMAT_SEPARATOR, parseCommit } from '../../bin/git';
+import { GIT_FORMAT_SEPARATOR, parseCommit } from '../../bin/git.js';
 
 describe('parseCommit', () => {
-
     describe('valid commit strings', () => {
         it('should parse a basic commit string correctly', () => {
             const commitString = `abc123${GIT_FORMAT_SEPARATOR}John Doe<john@example.com>${GIT_FORMAT_SEPARATOR}Mon, 25 Dec 2023 10:30:00 +0100${GIT_FORMAT_SEPARATOR}Add new feature`;
@@ -13,7 +12,7 @@ describe('parseCommit', () => {
                 sha: 'abc123',
                 author: 'John Doe<john@example.com>',
                 date: 'Mon, 25 Dec 2023 10:30:00 +0100',
-                message: 'Add new feature'
+                message: 'Add new feature',
             });
         });
 
@@ -26,7 +25,7 @@ describe('parseCommit', () => {
                 sha: 'def456',
                 author: 'Jane Smith<jane@example.com>',
                 date: 'Tue, 26 Dec 2023 14:15:00 +0100',
-                message: 'test: commit with double quotes: \"'
+                message: 'test: commit with double quotes: "',
             });
         });
 
@@ -39,7 +38,7 @@ describe('parseCommit', () => {
                 sha: 'jkl012',
                 author: 'María García<maria@example.com>',
                 date: 'Thu, 28 Dec 2023 16:20:00 +0100',
-                message: 'Add émojis 🚀 and "special" chars'
+                message: 'Add émojis 🚀 and "special" chars',
             });
         });
 
@@ -52,7 +51,7 @@ describe('parseCommit', () => {
                 sha: 'mno345',
                 author: 'Test User<test@example.com>',
                 date: 'Fri, 29 Dec 2023 11:00:00 +0100',
-                message: ''
+                message: '',
             });
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,19 +2,15 @@
     "extends": "@apify/tsconfig",
     "compilerOptions": {
         "declaration": true,
-        "module": "ES2022",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
         "target": "ES2022",
         "outDir": "dist",
         "noUnusedLocals": false,
         "strict": true,
         "esModuleInterop": true,
         "lib": ["DOM", "es2021"],
-        "skipLibCheck": true,
+        "skipLibCheck": true
     },
-    "include": [
-        "./index.ts",
-        "./bin/**/*",
-        "./lib/**/*",
-        "./test/**/*",
-    ]
+    "include": ["./index.ts", "./bin/**/*", "./lib/**/*", "./test/**/*"]
 }


### PR DESCRIPTION
[CONTEXT](https://apify.slack.com/archives/C033WM3PXLK/p1768215248102279)

Allow for projects that use this to have `nodenext` as `module` and `moduleResolution` and fix typing issues around expect and its extensions

The declaration file change was done according to [vitest docs](https://vitest.dev/guide/extending-matchers.html)