### PR TITLE
fix: file diffs between commits

### DIFF
--- a/bin/git.ts
+++ b/bin/git.ts
@@ -4,49 +4,34 @@ import { spawnCommandInGhWorkspace } from './utils.js';
 export const GIT_FORMAT_SEPARATOR = '»¦«';
 const GIT_LOG_FORMAT = ['%H', '%aN<%aE>', '%aD', '%s'].join(GIT_FORMAT_SEPARATOR);
 
-export const getBranchLastCommit = (branch: string): Commit => {
-    const commitString = spawnCommandInGhWorkspace(`git log -1 --pretty=format:'${GIT_LOG_FORMAT}' ${branch}`);
-    const commit = parseCommit(commitString);
-    return commit;
-};
-
+/**
+ * Gets the list of changed files between the given commits (inclusive).
+ */
 export const getChangedFiles = (commits: Commit[]) => {
-    const changedFiles =
-        commits.length === 1
-            ? spawnCommandInGhWorkspace(`git show --pretty='format:' --name-only ${commits[0].sha}`)
-            : spawnCommandInGhWorkspace(`git diff --name-only ${commits[0].sha}..${commits[commits.length - 1].sha}`);
+    const changedFiles = spawnCommandInGhWorkspace(
+        `git diff --name-only ${commits[0].sha}~..${commits[commits.length - 1].sha}`,
+    );
+
     return changedFiles.split('\n');
 };
 
+/**
+ * Gets the commits between sourceBranch and targetBranch (exclusive).
+ * - If baseCommit is provided, only returns commits after the baseCommit.
+ */
 export const getCommits = ({ sourceBranch, targetBranch, baseCommit: baseCommitSha }: Config): Commit[] => {
-    const targetBranchCommit = getBranchLastCommit(targetBranch);
-    const sourceBranchCommit = getBranchLastCommit(sourceBranch);
-    let baseCommit: Commit | undefined;
-    if (baseCommitSha) {
-        try {
-            baseCommit = getCommitInfo(baseCommitSha);
-        } catch (err) {
-            console.warn(`Failed to get base commit "${baseCommitSha}", it will not be used: ${err}`);
-        }
-    }
-    // const baseCommit = baseCommitSha !== undefined ?  : undefined;
-    // const gitOutputFormat = '{"sha":"%H","author":"%aN<%aE>","date":"%aD","message":"%f"}';
-    // console.log(`git log --pretty=format:"${gitOutputFormat}" ${targetBranch}..${sourceBranch}`);
-    // return [];
-    const base = getBaseCommit(sourceBranchCommit, targetBranchCommit);
     const commitsStrings = spawnCommandInGhWorkspace(
-        `git log --pretty=format:'${GIT_LOG_FORMAT}' ${base.sha}..${sourceBranchCommit.sha}`
+        `git log --pretty=format:'${GIT_LOG_FORMAT}' ${targetBranch}..${sourceBranch}`,
     ).split('\n');
-    const commits = commitsStrings.map((commitString) => parseCommit(commitString)) as Commit[];
+    const commits = commitsStrings.map((commitString) => parseCommit(commitString));
     commits.reverse();
-    const baseCommitIndex = baseCommit ? commits.findIndex(({ sha }) => sha === baseCommit.sha) : -1;
-    return commits.slice(baseCommitIndex + 1);
-};
 
-export const getBaseCommit = (target: Commit, source: Commit): Commit => {
-    const baseCommitSha = spawnCommandInGhWorkspace(`git merge-base ${target.sha} ${source.sha}`);
-    const baseCommit = getCommitInfo(baseCommitSha);
-    return baseCommit;
+    const baseCommitIndex = commits.findIndex((commit) => commit.sha === baseCommitSha);
+
+    const hasBaseCommit = baseCommitIndex !== -1;
+    if (hasBaseCommit) return commits.slice(baseCommitIndex + 1);
+
+    return commits;
 };
 
 export const getCommitInfo = (commitSha: string): Commit => {

--- a/test/unit/bin/git.test.ts
+++ b/test/unit/bin/git.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { getChangedFiles, getCommits } from '../../../bin/git.js';
+import * as Utils from '../../../bin/utils.js';
+
+describe('getCommits', () => {
+    const sourceBranch = 'feature-branch';
+    const targetBranch = 'main';
+
+    const commit1 = 'Commit1»¦«Author1»¦«Date1»¦«First Change On Feature';
+    const commit2 = 'Commit2»¦«Author1»¦«Date2»¦«Second Change On Feature';
+    const commit3 = 'Commit3»¦«Author1»¦«Date3»¦«Third Change On Feature';
+
+    let gitCommandSpy: MockInstance;
+
+    beforeEach(() => {
+        gitCommandSpy = vi
+            .spyOn(Utils, 'spawnCommandInGhWorkspace')
+            .mockReturnValue(`${commit3}\n${commit2}\n${commit1}`);
+    });
+
+    it('should return commits between source and target branches', () => {
+        // Act
+        const commits = getCommits({ sourceBranch, targetBranch });
+
+        // Assert
+        expect(commits).toStrictEqual([
+            { sha: 'Commit1', author: 'Author1', date: 'Date1', message: 'First Change On Feature' },
+            { sha: 'Commit2', author: 'Author1', date: 'Date2', message: 'Second Change On Feature' },
+            { sha: 'Commit3', author: 'Author1', date: 'Date3', message: 'Third Change On Feature' },
+        ]);
+
+        expect(gitCommandSpy).toHaveBeenCalledTimes(1);
+        expect(gitCommandSpy).toHaveBeenCalledWith(
+            `git log --pretty=format:'%H»¦«%aN<%aE>»¦«%aD»¦«%s' main..feature-branch`,
+        );
+    });
+
+    it('should return commits after the base commit if provided', () => {
+        // Act
+        const commits = getCommits({ sourceBranch, targetBranch, baseCommit: 'Commit1' });
+
+        // Assert
+        expect(commits).toStrictEqual([
+            { sha: 'Commit2', author: 'Author1', date: 'Date2', message: 'Second Change On Feature' },
+            { sha: 'Commit3', author: 'Author1', date: 'Date3', message: 'Third Change On Feature' },
+        ]);
+
+        expect(gitCommandSpy).toHaveBeenCalledTimes(1);
+        expect(gitCommandSpy).toHaveBeenCalledWith(
+            `git log --pretty=format:'%H»¦«%aN<%aE>»¦«%aD»¦«%s' main..feature-branch`,
+        );
+    });
+
+    it('should return all commits if base commit is not found', () => {
+        // Act
+        const commits = getCommits({ sourceBranch, targetBranch, baseCommit: 'NonExistingCommit' });
+
+        // Assert
+        expect(commits).toStrictEqual([
+            { sha: 'Commit1', author: 'Author1', date: 'Date1', message: 'First Change On Feature' },
+            { sha: 'Commit2', author: 'Author1', date: 'Date2', message: 'Second Change On Feature' },
+            { sha: 'Commit3', author: 'Author1', date: 'Date3', message: 'Third Change On Feature' },
+        ]);
+
+        expect(gitCommandSpy).toHaveBeenCalledTimes(1);
+        expect(gitCommandSpy).toHaveBeenCalledWith(
+            `git log --pretty=format:'%H»¦«%aN<%aE>»¦«%aD»¦«%s' main..feature-branch`,
+        );
+    });
+});
+
+describe('getChangedFiles', () => {
+    let gitCommandSpy: MockInstance;
+
+    beforeEach(() => {
+        gitCommandSpy = vi.spyOn(Utils, 'spawnCommandInGhWorkspace').mockReturnValue('file1.txt\nfolder/file2.txt');
+    });
+
+    it('should return changed files between commits', () => {
+        // Arrange
+        const commits = [
+            { sha: 'Commit1', author: '', date: '', message: '' },
+            { sha: 'Commit3', author: '', date: '', message: '' },
+        ];
+
+        // Act
+        const changedFiles = getChangedFiles(commits);
+
+        // Assert
+        expect(changedFiles).toStrictEqual(['file1.txt', 'folder/file2.txt']);
+
+        expect(gitCommandSpy).toHaveBeenCalledTimes(1);
+        expect(gitCommandSpy).toHaveBeenCalledWith(`git diff --name-only Commit1~..Commit3`);
+    });
+
+    it('should handle only one commit', () => {
+        // Arrange
+        const commits = [{ sha: 'Commit1', author: '', date: '', message: '' }];
+
+        // Act
+        const changedFiles = getChangedFiles(commits);
+
+        // Assert
+        expect(changedFiles).toStrictEqual(['file1.txt', 'folder/file2.txt']);
+
+        expect(gitCommandSpy).toHaveBeenCalledTimes(1);
+        expect(gitCommandSpy).toHaveBeenCalledWith(`git diff --name-only Commit1~..Commit1`);
+    });
+});


### PR DESCRIPTION
Fixes #48

Turns out the fix was really simple and we just have to use the first commit -1 (`${commitHash}~`) in the diff before the last commit. Now it should include the base commit in the diff check and not be off by one.

But because I've already worked on the other thing, I'm keeping the refactored version in 😠  