### PR TITLE
feat: annotate runs with test names

### DIFF
--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -111,7 +111,7 @@ export const testStandbyActor = <I = any, O = any>(
         const runs = (await apifyClient.task(taskId).runs().list()).items;
         for (const run of runs) {
             const runLink = generateRunLink(run);
-            await annotate(runLink, 'run_link');
+            await annotate(`${name} - ${runLink}`, 'run_link');
         }
 
         if (taskId) {
@@ -253,7 +253,7 @@ const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) =>
         const run = await actor.call(actorInput, { build, ...options });
 
         const runLink = generateRunLink(run);
-        await annotate(runLink, 'run_link');
+        await annotate(`${task.name} - ${runLink}`, 'run_link');
         // @ts-expect-error: `TaskMeta` cannot be retyped
         task.meta = {
             runId: run.id,


### PR DESCRIPTION
I find it hard to match platform `runId` with the specific (failing) test, so here I'm adding a test name annotation. Instead of current logs (example from Google Maps repo):

```
...
Notice: https://console.apify.com/view/runs/ypXM7w1HCPBisKMtZ

Notice: https://console.apify.com/view/runs/4395SRjaZDCVkz2DN

Notice: https://console.apify.com/view/runs/teWITAF1KFAURoO7b
...
```

it will display something like this:

```
...
Notice: Google Maps Extractor - works correctly - https://console.apify.com/view/runs/fYfq6Uf6fgyahUBX4

Notice: Google Maps Actor - works with search StartUrl - https://console.apify.com/view/runs/XQaPbDRhGDG0lZhvo

Notice: works with filter string - https://console.apify.com/view/runs/9fG7Il7aZivJ4455X
...
```

Tested locally with `npx vitest --reporter=github-actions` flag.