### PR TITLE
feat: make slack notification explictly opt in

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -144,7 +144,11 @@ await yargs()
             console.error(JSON.stringify(builds));
 
             // TODO: build circle actors
-            if (!notifySlack) return;
+            
+            if (!notifySlack) {
+                console.error(`Skipping slack notification. If you want to enable it, add --notify-slack flag and make sure SLACK_TOKEN_RELEASES_BOT env variable is set.`);
+            };
+
             await notifyToSlack({
                 changedFiles,
                 commits,

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -9,7 +9,7 @@ import { runBuilds } from './build.js';
 import { getChangedFiles, getCommits } from './git.js';
 import { getPushData } from './github.js';
 import { notifyToSlack } from './slack.js';
-import { reportTestRestuls } from './test-report.js';
+import { reportTestResults } from './test-report.js';
 
 /**
  * Middlewares to be run before every command execution
@@ -78,11 +78,12 @@ await yargs()
         (args) =>
             args
                 .option('report-file', { type: 'string', demandOption: true })
+                .option('notify-slack', { type: 'boolean', default: false })
                 .option('job-url', { type: 'string' })
                 .option('workflow-name', { type: 'string' })
                 .option('repository', { type: 'string' }),
         async (args) => {
-            await reportTestRestuls(args);
+            await reportTestResults(args);
         }
     )
     .command(

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -78,10 +78,9 @@ await yargs()
         (args) =>
             args
                 .option('report-file', { type: 'string', demandOption: true })
-                .option('notify-slack', { type: 'boolean', default: false })
+                .option('report-slack-channel', { type: 'string' })
                 .option('job-url', { type: 'string' })
-                .option('workflow-name', { type: 'string' })
-                .option('repository', { type: 'string' }),
+                .option('workflow-name', { type: 'string' }),
         async (args) => {
             await reportTestResults(args);
         }
@@ -121,7 +120,8 @@ await yargs()
             args
                 .option('push-event-path', { type: 'string', demandOption: true })
                 .option('dry-run', { type: 'boolean', default: false })
-                .option('notify-slack', { type: 'boolean', default: false }),
+                .option('report-slack-channel', { type: 'string' })
+                .option('release-slack-channel', { type: 'string' }),
         async (args) => {
             const { branch, changedFiles, repoUrl, commits, changelog, repository, author } = await getPushData(
                 args.pushEventPath
@@ -133,7 +133,7 @@ await yargs()
                 actorConfigs,
                 isLatest,
             });
-            const { dryRun, notifySlack } = args;
+            const { dryRun, reportSlackChannel, releaseSlackChannel } = args;
             const builds = await runBuilds({
                 isLatest,
                 repoUrl,
@@ -144,11 +144,6 @@ await yargs()
             console.error(JSON.stringify(builds));
 
             // TODO: build circle actors
-            
-            if (!notifySlack) {
-                console.error(`Skipping slack notification. If you want to enable it, add --notify-slack flag and make sure SLACK_TOKEN_RELEASES_BOT env variable is set.`);
-            };
-
             await notifyToSlack({
                 changedFiles,
                 commits,
@@ -156,6 +151,8 @@ await yargs()
                 repository,
                 dryRun,
                 author,
+                reportSlackChannel,
+                releaseSlackChannel,
             });
         }
     )

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -120,7 +120,8 @@ await yargs()
         (args) =>
             args
                 .option('push-event-path', { type: 'string', demandOption: true })
-                .option('dry-run', { type: 'boolean', default: false }),
+                .option('dry-run', { type: 'boolean', default: false })
+                .option('notify-slack', { type: 'boolean', default: false }),
         async (args) => {
             const { branch, changedFiles, repoUrl, commits, changelog, repository, author } = await getPushData(
                 args.pushEventPath
@@ -132,7 +133,7 @@ await yargs()
                 actorConfigs,
                 isLatest,
             });
-            const { dryRun } = args;
+            const { dryRun, notifySlack } = args;
             const builds = await runBuilds({
                 isLatest,
                 repoUrl,
@@ -143,6 +144,7 @@ await yargs()
             console.error(JSON.stringify(builds));
 
             // TODO: build circle actors
+            if (!notifySlack) return;
             await notifyToSlack({
                 changedFiles,
                 commits,

--- a/bin/slack.ts
+++ b/bin/slack.ts
@@ -9,6 +9,8 @@ type NotifyToSlackOptions = {
     commits: Commit[];
     dryRun: boolean;
     author: string;
+    releaseSlackChannel?: string;
+    reportSlackChannel?: string;
 };
 
 export const notifyToSlack = async ({
@@ -18,6 +20,8 @@ export const notifyToSlack = async ({
     repository,
     dryRun,
     author,
+    releaseSlackChannel,
+    reportSlackChannel,
 }: NotifyToSlackOptions) => {
     const slack = new WebClient(getEnvVar('SLACK_TOKEN_RELEASES_BOT'));
 
@@ -28,15 +32,14 @@ export const notifyToSlack = async ({
     let shortMessage = `${repository} --- New release (by ${author}):\n\n`;
 
     // This one is just for broader public that only cares about public facing changes
-    if (changelog) {
-        console.error(`=========================================`);
+    if (changelog && releaseSlackChannel) {
         shortMessage += `**Additions to the changelog**:\n\n${changelog}\n`;
-        const channel = '#delivery-public-actors';
-        console.error(`**Sending slack message to channel**: ${channel}.\n\n${shortMessage}`);
+        console.error(`=========================================`);
+        console.error(`**Sending slack message to channel**: ${releaseSlackChannel}.\n\n${shortMessage}`);
         console.error(`=========================================`);
         if (!dryRun) {
             await slack.chat.postMessage({
-                channel,
+                channel: releaseSlackChannel,
                 text: shortMessage,
             });
         }
@@ -49,15 +52,16 @@ export const notifyToSlack = async ({
     const longMessage = `${shortMessage}\n**Commit list**:\n${commitsMessage}\n\n${changedFilesMessage}`;
 
     // This one is for devs and project managers that need to know more details
-    const notifChannel = `#notif-${repository.toLowerCase()}`;
-    console.error(`=========================================`);
-    console.error(`Sending slack message to channel: ${notifChannel}.\n\n${longMessage}`);
-    console.error(`=========================================`);
-    if (!dryRun) {
-        await slack.chat.postMessage({
-            text: longMessage,
-            channel: notifChannel,
-        });
+    if (reportSlackChannel) {
+        console.error(`=========================================`);
+        console.error(`Sending slack message to channel: ${reportSlackChannel}.\n\n${longMessage}`);
+        console.error(`=========================================`);
+        if (!dryRun) {
+            await slack.chat.postMessage({
+                text: longMessage,
+                channel: reportSlackChannel,
+            });
+        }
     }
 };
 

--- a/bin/test-report.ts
+++ b/bin/test-report.ts
@@ -2,21 +2,23 @@ import fs from 'fs/promises';
 import { sendSlackMessage } from './slack.js';
 import { getEnvVar } from './utils.js';
 
-interface ReportTestRestulsOptions {
+interface ReportTestResultsOptions {
     reportFile: string
     dryRun: boolean
+    notifySlack: boolean
     jobUrl?: string
     repository?: string
     workflowName?: string
 }
 
-export const reportTestRestuls = async ({
+export const reportTestResults = async ({
     dryRun,
+    notifySlack,
     reportFile: jsonResultsPath,
     jobUrl,
     workflowName,
     repository,
-}: ReportTestRestulsOptions) => {
+}: ReportTestResultsOptions) => {
     const results: JsonTestResults = JSON.parse((await fs.readFile(jsonResultsPath)).toString());
     const passed: JsonAssertionResult[] = [];
     const failed: JsonAssertionResult[] = [];
@@ -78,16 +80,21 @@ export const reportTestRestuls = async ({
     slackMessage += `\n\n${failedAssertions[0].message} --- <${failedAssertions[0].runLink}|${failedAssertions[0].actorName}>`;
     const blocks = failedAssertions.slice(1).map(({ message, runLink, actorName }) => `• ${message} --- <${runLink}|${actorName}>`);
 
-    if (!repository) {
-        console.error(`Repository not provided, not sending slack notification`);
-        return
-    }
-
-    // remove repository-owner part
-    const channel = `#notif-${repository.replace(/[^/]+\//, '')}`;
-    console.error(`Sending a notification to slack channel ${channel}`);
+    const channel = repository ? `#notif-${repository.replace(/[^/]+\//, '')}` : null;
+    console.error(`Slack channel: ${channel ?? '(no repository provided)'}`);
     console.error('SLACK:', slackMessage);
     console.error('\tblocks:', blocks.join('\n\t\t'));
+
+    if (!notifySlack) {
+        console.error(`Skipping slack notification. If you want to enable it, add --notify-slack flag and make sure SLACK_TOKEN_TESTS_BOT env variable is set.`);
+        return;
+    }
+
+    if (!channel) {
+        console.error(`Repository not provided, skipping slack notification`);
+        return;
+    }
+
     if (!dryRun) {
         const slackToken = getEnvVar('SLACK_TOKEN_TESTS_BOT');
         await sendSlackMessage(channel, slackMessage, blocks, slackToken);

--- a/bin/test-report.ts
+++ b/bin/test-report.ts
@@ -5,19 +5,17 @@ import { getEnvVar } from './utils.js';
 interface ReportTestResultsOptions {
     reportFile: string
     dryRun: boolean
-    notifySlack: boolean
+    reportSlackChannel?: string
     jobUrl?: string
-    repository?: string
     workflowName?: string
 }
 
 export const reportTestResults = async ({
     dryRun,
-    notifySlack,
+    reportSlackChannel,
     reportFile: jsonResultsPath,
     jobUrl,
     workflowName,
-    repository,
 }: ReportTestResultsOptions) => {
     const results: JsonTestResults = JSON.parse((await fs.readFile(jsonResultsPath)).toString());
     const passed: JsonAssertionResult[] = [];
@@ -67,6 +65,11 @@ export const reportTestResults = async ({
     console.error();
     console.error(`PASSED: ${passed.length}, FAILED: ${failed.length}`);
     console.error();
+    
+    if (!reportSlackChannel) {
+        console.error(`Skipping slack notification. If you want to enable it, add --report-slack-channel flag and make sure SLACK_TOKEN_TESTS_BOT env variable is set.`);
+        return;
+    }
 
     if (failedAssertions.length === 0) {
         return;
@@ -75,29 +78,21 @@ export const reportTestResults = async ({
     // TODO: add slack profiles
     const total = failed.length + passed.length;
     const jobLink = jobUrl ? ` Check <${jobUrl}|the job>.` : '';
-    let slackMessage = `\`${workflowName ?? '-'}\`: *${repository ?? '-'}*`;
+    let slackMessage = `\`${workflowName ?? '-'}\``;
     slackMessage += `: has ${failedAssertions.length} failed assertions. Failing test suites: ${failed.length}/${total}.${jobLink}`;
     slackMessage += `\n\n${failedAssertions[0].message} --- <${failedAssertions[0].runLink}|${failedAssertions[0].actorName}>`;
     const blocks = failedAssertions.slice(1).map(({ message, runLink, actorName }) => `• ${message} --- <${runLink}|${actorName}>`);
 
-    const channel = repository ? `#notif-${repository.replace(/[^/]+\//, '')}` : null;
-    console.error(`Slack channel: ${channel ?? '(no repository provided)'}`);
     console.error('SLACK:', slackMessage);
     console.error('\tblocks:', blocks.join('\n\t\t'));
 
-    if (!notifySlack) {
-        console.error(`Skipping slack notification. If you want to enable it, add --notify-slack flag and make sure SLACK_TOKEN_TESTS_BOT env variable is set.`);
-        return;
-    }
-
-    if (!channel) {
-        console.error(`Repository not provided, skipping slack notification`);
+    if (!reportSlackChannel) {
         return;
     }
 
     if (!dryRun) {
         const slackToken = getEnvVar('SLACK_TOKEN_TESTS_BOT');
-        await sendSlackMessage(channel, slackMessage, blocks, slackToken);
+        await sendSlackMessage(reportSlackChannel, slackMessage, blocks, slackToken);
     }
 };
 


### PR DESCRIPTION
Closes #55 

Now `report-tests` and `release` commands must include `--notify-slack` or it will not trigger the notify notification, but just show the failed errors in the terminal.