### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "apify-test-tools",
-    "version": "0.5.7",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "apify-test-tools",
-            "version": "0.5.7",
+            "version": "0.6.0",
             "license": "ISC",
             "dependencies": {
                 "@apify/consts": "^2.43.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-test-tools",
-    "version": "0.5.7",
+    "version": "0.6.0",
     "type": "module",
     "description": "TBD",
     "repository": {


### PR DESCRIPTION
Bump version to `0.6.0`
Note: release workflow is expected to fail, this version will be released on NPM manually.