### PR TITLE
fix(bin): case sensitivity in file path handling for git operations

### DIFF
--- a/bin/diff-changes.ts
+++ b/bin/diff-changes.ts
@@ -81,6 +81,7 @@ const classifyFileChange = (originalFilePath: string, actorConfigs: ActorConfig[
         if (lowercaseFilePath.endsWith('readme.md')) {
             return { impact: 'cosmetic', includes: actorConfigChanged };
         }
+        // originalFilePath must be used here (not lowercaseFilePath) — git show is case-sensitive on Linux
         if (lowercaseFilePath.endsWith('.json') && isCosmeticOnlyJsonSchemaChange(commits, originalFilePath)) {
             return { impact: 'cosmetic', includes: actorConfigChanged };
         }

--- a/bin/diff-changes.ts
+++ b/bin/diff-changes.ts
@@ -51,8 +51,9 @@ type FileChange =
           includes: 'all-actors' | ActorConfig;
       };
 
-// originalFilePath preserves the exact case from git diff, needed for `git show` on case-sensitive filesystems
-const classifyFileChange = (lowercaseFilePath: string, originalFilePath: string, actorConfigs: ActorConfig[], commits: Commit[]): FileChange => {
+const classifyFileChange = (originalFilePath: string, actorConfigs: ActorConfig[], commits: Commit[]): FileChange => {
+    // Lowercase for case-insensitive matching; keep original for git show (case-sensitive on Linux)
+    const lowercaseFilePath = originalFilePath.toLowerCase();
     if (isIgnoredTopLevelFile(lowercaseFilePath)) {
         return { impact: 'ignored' };
     }
@@ -103,8 +104,7 @@ export const getChangedActors = ({
     const actorConfigsWithoutStandalone = actorConfigs.filter(({ isStandalone }) => !isStandalone);
 
     for (const originalFilePath of filepathsChanged) {
-        const lowercaseFilePath = originalFilePath.toLowerCase();
-        const fileChange = classifyFileChange(lowercaseFilePath, originalFilePath, actorConfigs, commits);
+        const fileChange = classifyFileChange(originalFilePath, actorConfigs, commits);
         if (fileChange.impact === 'ignored') {
             continue;
         }
@@ -127,17 +127,17 @@ export const getChangedActors = ({
 
     // All below here is just for logging
     const ignoredFilesChanged = filepathsChanged.filter(
-        (file) => classifyFileChange(file.toLowerCase(), file, actorConfigs, commits).impact === 'ignored',
+        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'ignored',
     );
     console.error(`[DIFF]: Ignored files (don't trigger test or build): ${ignoredFilesChanged.join(', ')}`);
 
     const cosmeticFilesChanged = filepathsChanged.filter(
-        (file) => classifyFileChange(file.toLowerCase(), file, actorConfigs, commits).impact === 'cosmetic',
+        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'cosmetic',
     );
     console.error(`[DIFF]: Cosmetic files (should only trigger release build): ${cosmeticFilesChanged.join(', ')}`);
 
     const functionalFilesChanged = filepathsChanged.filter(
-        (file) => classifyFileChange(file.toLowerCase(), file, actorConfigs, commits).impact === 'functional',
+        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'functional',
     );
     console.error(`[DIFF]: Functional files (trigger test & release build): ${functionalFilesChanged.join(', ')}`);
 

--- a/bin/diff-changes.ts
+++ b/bin/diff-changes.ts
@@ -51,7 +51,8 @@ type FileChange =
           includes: 'all-actors' | ActorConfig;
       };
 
-const classifyFileChange = (lowercaseFilePath: string, actorConfigs: ActorConfig[], commits: Commit[]): FileChange => {
+// originalFilePath preserves the exact case from git diff, needed for `git show` on case-sensitive filesystems
+const classifyFileChange = (lowercaseFilePath: string, originalFilePath: string, actorConfigs: ActorConfig[], commits: Commit[]): FileChange => {
     if (isIgnoredTopLevelFile(lowercaseFilePath)) {
         return { impact: 'ignored' };
     }
@@ -79,7 +80,7 @@ const classifyFileChange = (lowercaseFilePath: string, actorConfigs: ActorConfig
         if (lowercaseFilePath.endsWith('readme.md')) {
             return { impact: 'cosmetic', includes: actorConfigChanged };
         }
-        if (lowercaseFilePath.endsWith('.json') && isCosmeticOnlyJsonSchemaChange(commits, lowercaseFilePath)) {
+        if (lowercaseFilePath.endsWith('.json') && isCosmeticOnlyJsonSchemaChange(commits, originalFilePath)) {
             return { impact: 'cosmetic', includes: actorConfigChanged };
         }
 
@@ -101,10 +102,9 @@ export const getChangedActors = ({
 
     const actorConfigsWithoutStandalone = actorConfigs.filter(({ isStandalone }) => !isStandalone);
 
-    const lowercaseFiles = filepathsChanged.map((file) => file.toLowerCase());
-
-    for (const lowercaseFilePath of lowercaseFiles) {
-        const fileChange = classifyFileChange(lowercaseFilePath, actorConfigs, commits);
+    for (const originalFilePath of filepathsChanged) {
+        const lowercaseFilePath = originalFilePath.toLowerCase();
+        const fileChange = classifyFileChange(lowercaseFilePath, originalFilePath, actorConfigs, commits);
         if (fileChange.impact === 'ignored') {
             continue;
         }
@@ -126,18 +126,18 @@ export const getChangedActors = ({
     const actorsChanged = Array.from(actorsChangedMap.values());
 
     // All below here is just for logging
-    const ignoredFilesChanged = lowercaseFiles.filter(
-        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'ignored',
+    const ignoredFilesChanged = filepathsChanged.filter(
+        (file) => classifyFileChange(file.toLowerCase(), file, actorConfigs, commits).impact === 'ignored',
     );
     console.error(`[DIFF]: Ignored files (don't trigger test or build): ${ignoredFilesChanged.join(', ')}`);
 
-    const cosmeticFilesChanged = lowercaseFiles.filter(
-        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'cosmetic',
+    const cosmeticFilesChanged = filepathsChanged.filter(
+        (file) => classifyFileChange(file.toLowerCase(), file, actorConfigs, commits).impact === 'cosmetic',
     );
     console.error(`[DIFF]: Cosmetic files (should only trigger release build): ${cosmeticFilesChanged.join(', ')}`);
 
-    const functionalFilesChanged = lowercaseFiles.filter(
-        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'functional',
+    const functionalFilesChanged = filepathsChanged.filter(
+        (file) => classifyFileChange(file.toLowerCase(), file, actorConfigs, commits).impact === 'functional',
     );
     console.error(`[DIFF]: Functional files (trigger test & release build): ${functionalFilesChanged.join(', ')}`);
 


### PR DESCRIPTION
## Summary
This change fixes a case sensitivity issue in file path handling where lowercase file paths were being passed to `git show`, which fails on case-sensitive filesystems like Linux. The fix preserves the original file path casing for git operations while maintaining case-insensitive matching for classification logic.

## Key Changes
- Modified `classifyFileChange` to accept `originalFilePath` instead of pre-lowercased paths
- Moved the lowercase conversion inside the function to keep the original casing available
- Updated the call to `isCosmeticOnlyJsonSchemaChange` to use `originalFilePath` instead of `lowercaseFilePath` since git operations are case-sensitive on Linux
- Removed the pre-processing step that converted all file paths to lowercase before classification
- Updated logging sections to use original file paths from `filepathsChanged` instead of the lowercased array

## Implementation Details
- The lowercase conversion is now performed locally within `classifyFileChange` for case-insensitive matching logic
- A comment clarifies why `originalFilePath` must be used for the `isCosmeticOnlyJsonSchemaChange` call
- This ensures git operations receive the correct file path casing while classification logic remains case-insensitive

https://claude.ai/code/session_01NHgddik3UA7sDUi12hBUud