### PR TITLE
feat: add default 1 hour test run timeout

### DIFF
--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -11,3 +11,8 @@ export const TO_FINISH_WITH_OPTIONS: ToFinishWithOptionsWithDefaults = {
     maxRetriesPerRequest: null,
     forbiddenLogs: ['ReferenceError', 'TypeError'],
 };
+
+/**
+ * Both the test runs and the vitest test specs should finish in this time - 1 hour
+ */
+export const DEFAULT_TEST_RUN_DURATION_MS = 60_000 * 60; // 1 hour

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -15,4 +15,4 @@ export const TO_FINISH_WITH_OPTIONS: ToFinishWithOptionsWithDefaults = {
 /**
  * Both the test runs and the vitest test specs should finish in this time - 1 hour
  */
-export const DEFAULT_TEST_RUN_DURATION_MS = 60_000 * 60; // 1 hour
+export const DEFAULT_TEST_RUN_DURATION_MS = 60 * 60 * 1000; // 1 hour

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -3,6 +3,7 @@ import { ApifyClient } from 'apify-client';
 import type { SuiteFactory, TestContext, TestFunction } from 'vitest';
 import { describe as vitestDescribe, ExpectStatic, test as vitestTest } from 'vitest';
 
+import { DEFAULT_TEST_RUN_DURATION_MS } from './consts.js';
 import { extendExpect } from './extend-expect.js';
 import { RunTestResult } from './run-test-result.js';
 import type { ActorBuild, ActorTestOptions, RunOptions } from './types.js';
@@ -37,7 +38,7 @@ const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
     // we want to run tests concurrently
     concurrent: true,
     // test should finish within 1 hour
-    timeout: 60_000 * 60,
+    timeout: DEFAULT_TEST_RUN_DURATION_MS,
 };
 
 export const describe = (name: string, fn?: SuiteFactory<object>, options: ActorTestOptions = DEFAULT_TEST_OPTIONS) => {
@@ -46,6 +47,8 @@ export const describe = (name: string, fn?: SuiteFactory<object>, options: Actor
 
 const DEFAULT_TEST_ACTOR_OPTIONS: ActorTestOptions = {
     retry: 1,
+    // prevent orphaned runs
+    timeout: DEFAULT_TEST_RUN_DURATION_MS,
 };
 
 export const testActor = <T>(
@@ -124,7 +127,7 @@ export const testTestActor = <T>(
             expect: extendExpect(expect),
             // @ts-expect-error: this just to test custom matchers
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            run: () => { },
+            run: () => {},
             ...rest,
         });
     });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -128,7 +128,7 @@ export interface ActorMatchers<R = unknown> {
     hard: <T>(actual: T, message?: string) => Assertion;
 }
 
-export type ActorTestOptions = Omit<TestOptions, 'retry'> & {
+export type ActorTestOptions = Omit<TestOptions, 'retry' | 'timeout'> & {
     /**
      * Times to retry the test if fails. Useful for making flaky tests more stable.
      * When retries is up, the last test error will be thrown.
@@ -137,6 +137,13 @@ export type ActorTestOptions = Omit<TestOptions, 'retry'> & {
      */
     // we are just extending the docs here to replace the default value, otherwise it's the exact same
     retry?: TestOptions['retry'];
+    /**
+     * Timeout for the actor run in milliseconds. Zero value means there is no timeout.
+     * - If `undefined`, the run uses timeout of the default Actor run configuration.
+     *
+     * @default 60_000 * 60 // 1 hour
+     */
+    timeout?: ActorCallOptions['timeout'];
 };
 
 declare module 'vitest' {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -141,7 +141,7 @@ export type ActorTestOptions = Omit<TestOptions, 'retry' | 'timeout'> & {
      * Timeout for the actor run in milliseconds. Zero value means there is no timeout.
      * - If `undefined`, the run uses timeout of the default Actor run configuration.
      *
-     * @default 60_000 * 60 // 1 hour
+     * @default 60 * 60 * 1000 // 1 hour
      */
     timeout?: ActorCallOptions['timeout'];
 };


### PR DESCRIPTION
https://apify.slack.com/archives/C059M9L8ZLP/p1776154991254529
To prevent orphaned actor runs from continuing to run even after the tests have ended.

