### PR TITLE
refactor(build): make it obvious what files are actually ignored

### DIFF
--- a/bin/diff-changes.ts
+++ b/bin/diff-changes.ts
@@ -44,7 +44,7 @@ const isIgnoredTopLevelFile = (lowercaseFilePath: string) => {
 type FileChange =
     | { impact: 'ignored' }
     // Only things that influence how the Actor looks - e.g. README and CHANGELOG files, schema titles, descriptions, reordering, etc. We only need to rebuild on release
-    | { impact: 'cosmetic'; includes: 'all-actors' | ActorConfig }
+    | { impact: 'cosmetic'; semanticallyVerified: boolean; includes: 'all-actors' | ActorConfig }
     // Influences how the Actor works - we need to run tests
     | {
           impact: 'functional';
@@ -59,7 +59,7 @@ const classifyFileChange = (originalFilePath: string, actorConfigs: ActorConfig[
     }
 
     if (lowercaseFilePath.endsWith('changelog.md')) {
-        return { impact: 'cosmetic', includes: 'all-actors' };
+        return { impact: 'cosmetic', semanticallyVerified: false, includes: 'all-actors' };
     }
 
     const actorFolderInfo = maybeParseActorFolder(lowercaseFilePath);
@@ -79,11 +79,11 @@ const classifyFileChange = (originalFilePath: string, actorConfigs: ActorConfig[
             return { impact: 'ignored' };
         }
         if (lowercaseFilePath.endsWith('readme.md')) {
-            return { impact: 'cosmetic', includes: actorConfigChanged };
+            return { impact: 'cosmetic', semanticallyVerified: false, includes: actorConfigChanged };
         }
         // originalFilePath must be used here (not lowercaseFilePath) — git show is case-sensitive on Linux
         if (lowercaseFilePath.endsWith('.json') && isCosmeticOnlyJsonSchemaChange(commits, originalFilePath)) {
-            return { impact: 'cosmetic', includes: actorConfigChanged };
+            return { impact: 'cosmetic', semanticallyVerified: true, includes: actorConfigChanged };
         }
 
         return { impact: 'functional', includes: actorConfigChanged };
@@ -127,20 +127,32 @@ export const getChangedActors = ({
     const actorsChanged = Array.from(actorsChangedMap.values());
 
     // All below here is just for logging
+    const formatFiles = (files: string[]) => (files.length > 0 ? files.join(', ') : '<no files>');
+
     const ignoredFilesChanged = filepathsChanged.filter(
         (file) => classifyFileChange(file, actorConfigs, commits).impact === 'ignored',
     );
-    console.error(`[DIFF]: Ignored files (don't trigger test or build): ${ignoredFilesChanged.join(', ')}`);
+    console.error(`[DIFF]: Ignored files (don't trigger test or build): ${formatFiles(ignoredFilesChanged)}`);
 
-    const cosmeticFilesChanged = filepathsChanged.filter(
-        (file) => classifyFileChange(file, actorConfigs, commits).impact === 'cosmetic',
+    const cosmeticChanges = filepathsChanged
+        .map((file) => ({ file, change: classifyFileChange(file, actorConfigs, commits) }))
+        .filter(({ change }) => change.impact === 'cosmetic') as {
+        file: string;
+        change: Extract<FileChange, { impact: 'cosmetic' }>;
+    }[];
+    const semanticallyVerifiedFiles = cosmeticChanges.filter(({ change }) => change.semanticallyVerified).map(({ file }) => file);
+    const inherentlyCosmeticFiles = cosmeticChanges.filter(({ change }) => !change.semanticallyVerified).map(({ file }) => file);
+    console.error(
+        `[DIFF]: Cosmetic-only JSON schema changes (semantically verified, only trigger release build): ${formatFiles(semanticallyVerifiedFiles)}`,
     );
-    console.error(`[DIFF]: Cosmetic files (should only trigger release build): ${cosmeticFilesChanged.join(', ')}`);
+    console.error(
+        `[DIFF]: Inherently cosmetic files (README, CHANGELOG — only trigger release build): ${formatFiles(inherentlyCosmeticFiles)}`,
+    );
 
     const functionalFilesChanged = filepathsChanged.filter(
         (file) => classifyFileChange(file, actorConfigs, commits).impact === 'functional',
     );
-    console.error(`[DIFF]: Functional files (trigger test & release build): ${functionalFilesChanged.join(', ')}`);
+    console.error(`[DIFF]: Functional files (trigger test & release build): ${formatFiles(functionalFilesChanged)}`);
 
     if (actorsChanged.length > 0) {
         const miniactors = actorsChanged.filter((config) => !config.isStandalone).map((config) => config.actorName);


### PR DESCRIPTION
I got these logs in CI:
<details>
```
Last validated (base) commit to be used for build & test: 
Actors in repo: apify/facebook-ads-scraper, apify/facebook-comments-scraper, apify/facebook-followers-following-scraper, apify/facebook-games-scraper, apify/facebook-groups-scraper, apify/facebook-likes-scraper, apify/facebook-marketplace-scraper, apify/facebook-page-contact-information, apify/facebook-pages-scraper, apify/facebook-photos-scraper, apify/facebook-posts-scraper, apify/facebook-reels-scraper, apify/facebook-reviews-scraper, apify/facebook-search-scraper, apify/facebook-url-to-id, apify/facebook-video-search-scraper, apify/meta-brand-collaboration-scraper
Standalone actors in repo: apify/facebook-events-scraper, apify/facebook-hashtag-scraper
git log --merges --pretty=format:%H origin/master..origin/feat/meta-brand-collaboration-input-examples 
git log --pretty=format:'%H»¦«%aN<%aE>»¦«%aD»¦«' origin/master..origin/feat/meta-brand-collaboration-input-examples
Base commit undefined not found in the commit range, returning all 1 commits
Commits being returned: f26568391a05bee819dc453e258c3b29e07da187
git diff --name-only f26568391a05bee819dc453e258c3b29e07da187~..f26568391a05bee819dc453e258c3b29e07da187 
Changed files (up to 50): actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json
git show f26568391a05bee819dc453e258c3b29e07da187~:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
git show f26568391a05bee819dc453e258c3b29e07da187:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
git show f26568391a05bee819dc453e258c3b29e07da187~:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
git show f26568391a05bee819dc453e258c3b29e07da187:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
[DIFF]: Ignored files (don't trigger test or build): 
git show f26568391a05bee819dc453e258c3b29e07da187~:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
git show f26568391a05bee819dc453e258c3b29e07da187:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
[DIFF]: Cosmetic files (should only trigger release build): actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json
git show f26568391a05bee819dc453e258c3b29e07da187~:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
git show f26568391a05bee819dc453e258c3b29e07da187:actors/apify_meta-brand-collaboration-scraper/.actor/INPUT_SCHEMA.json 
[DIFF]: Functional files (trigger test & release build): 
[DIFF]: No relevant files changed, skipping builds and tests
git remote get-url origin 
=========================================
STARTED BUILDS:
=========================================
FINISHED BUILDS:
=========================================
SUMMARY:
=========================================
actor_builds=[]
```
</details>

Suggesting that changes to an `INPUT_SCHEMA.json` never force rebuild - I tested it and found out it at least sometimes does, and then looking into the library to confirm that it consistently works. For other to not go into the same rabbit hole I think it makes sense to make these log changes.