### PR TITLE
feat: allow easy inversion of tests

### DIFF
--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -57,13 +57,14 @@ export const testActor = <T>(
     fn: TestFunction<{ run: ReturnType<typeof createStartRunFn<T>> }>,
     testOptions?: ActorTestOptions,
 ) => {
-    const options = {
+    const { fails, ...restOptions } = {
         ...DEFAULT_TEST_ACTOR_OPTIONS,
         ...testOptions,
     };
     const name = `${actorName}: ${testName}`;
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorName);
-    vitestTest.runIf(shouldRun)(name, options, async <TYPE extends TestContext>(context: TYPE) => {
+    const vitestTestFn = fails && shouldRun ? vitestTest.fails : vitestTest.runIf(shouldRun);
+    vitestTestFn(name, restOptions, async <TYPE extends TestContext>(context: TYPE) => {
         const { expect, ...rest } = context;
         await fn({
             expect: extendExpect(expect),
@@ -86,14 +87,15 @@ export const testStandbyActor = <I = any, O = any>(
     fn: TestFunction<{ callStandby: ReturnType<typeof createStartStandbyFn<I, O>> }>,
     testOptions?: ActorTestOptions,
 ) => {
-    const options = {
+    const { fails, ...restOptions } = {
         ...DEFAULT_TEST_ACTOR_OPTIONS,
         ...testOptions,
     };
     const name = `${actorName}: ${testName}`;
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorName);
+    const vitestTestFn = fails && shouldRun ? vitestTest.fails : vitestTest.runIf(shouldRun);
 
-    vitestTest.runIf(shouldRun)(name, options, async <T extends TestContext>(context: T) => {
+    vitestTestFn(name, restOptions, async <T extends TestContext>(context: T) => {
         const standbyTask = await createStandbyTask(actorName, config.get(actorName)?.buildNumber);
         const { expect, ...rest } = context;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -144,6 +144,12 @@ export type ActorTestOptions = Omit<TestOptions, 'retry' | 'timeout'> & {
      * @default 60 * 60 * 1000 // 1 hour
      */
     timeout?: ActorCallOptions['timeout'];
+    /**
+     * Mark this test as expected to fail (wraps the underlying vitest test with `test.fails`).
+     * The test passes as long as it keeps failing, and alerts you (by failing) if it unexpectedly starts passing.
+     * Use this to keep a sentinel for known regressions without inverting assertions by hand.
+     */
+    fails?: boolean;
 };
 
 declare module 'vitest' {

--- a/test/unit/test-actor.test.ts
+++ b/test/unit/test-actor.test.ts
@@ -1,0 +1,115 @@
+import type * as Vitest from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Spy handles: mockFails is called directly as vitestTest.fails(name, opts, fn),
+// mockRunIf is called as vitestTest.runIf(condition) and returns mockRunIfFn.
+const mockRunIfFn = vi.fn();
+const mockRunIf = vi.fn(() => mockRunIfFn);
+const mockFails = vi.fn();
+
+// Mock the vitest module so lib.ts picks up our spies when dynamically imported.
+// We spread the real module so our test file's own `it`, `describe`, `expect` etc. still work.
+// We only replace `test` — `it` remains the real registration function used by this file.
+vi.mock('vitest', async (importOriginal) => {
+    const actual = await importOriginal<typeof Vitest>();
+    return {
+        ...actual,
+        test: Object.assign(vi.fn(), {
+            fails: mockFails,
+            runIf: mockRunIf,
+        }),
+    };
+});
+
+const ACTOR_BUILD = { actorName: 'my-actor', actorId: 'abc123', buildNumber: '1.0', buildId: 'build1' };
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+describe('testActor - fails option', () => {
+    beforeEach(() => {
+        // Fresh module so env vars read at lib.ts module level are re-evaluated each test.
+        vi.resetModules();
+        mockRunIf.mockClear();
+        mockRunIfFn.mockClear();
+        mockFails.mockClear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('calls vitestTest.fails when fails:true and actor is in the build list', async () => {
+        vi.stubEnv('ACTOR_BUILDS', JSON.stringify([ACTOR_BUILD]));
+
+        const { testActor } = await import('../../lib/lib.js');
+        testActor('my-actor', 'test name', noop, { fails: true });
+
+        expect(mockFails).toHaveBeenCalledOnce();
+        expect(mockRunIf).not.toHaveBeenCalled();
+    });
+
+    it('calls vitestTest.runIf(false) when fails:true but actor is not in the build list', async () => {
+        vi.stubEnv('ACTOR_BUILDS', JSON.stringify([]));
+
+        const { testActor } = await import('../../lib/lib.js');
+        testActor('my-actor', 'test name', noop, { fails: true });
+
+        expect(mockRunIf).toHaveBeenCalledWith(false);
+        expect(mockFails).not.toHaveBeenCalled();
+    });
+
+    it('calls vitestTest.runIf(true) when no fails option and actor is in the build list', async () => {
+        vi.stubEnv('ACTOR_BUILDS', JSON.stringify([ACTOR_BUILD]));
+
+        const { testActor } = await import('../../lib/lib.js');
+        testActor('my-actor', 'test name', noop);
+
+        expect(mockRunIf).toHaveBeenCalledWith(true);
+        expect(mockFails).not.toHaveBeenCalled();
+    });
+
+    it('strips the fails key from options forwarded to vitest', async () => {
+        vi.stubEnv('ACTOR_BUILDS', JSON.stringify([ACTOR_BUILD]));
+
+        const { testActor } = await import('../../lib/lib.js');
+        testActor('my-actor', 'test name', noop, { fails: true, retry: 2 });
+
+        const [, options] = mockFails.mock.calls[0] as [string, Record<string, unknown>, unknown];
+        expect(options).not.toHaveProperty('fails');
+        expect(options).toHaveProperty('retry', 2);
+    });
+
+    it('calls vitestTest.fails when fails:true and RUN_ALL_PLATFORM_TESTS is set (no build config)', async () => {
+        vi.stubEnv('ACTOR_BUILDS', JSON.stringify([]));
+        vi.stubEnv('RUN_ALL_PLATFORM_TESTS', '1');
+
+        const { testActor } = await import('../../lib/lib.js');
+        testActor('my-actor', 'test name', noop, { fails: true });
+
+        expect(mockFails).toHaveBeenCalledOnce();
+        expect(mockRunIf).not.toHaveBeenCalled();
+    });
+});
+
+describe('testStandbyActor - fails option', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        mockRunIf.mockClear();
+        mockRunIfFn.mockClear();
+        mockFails.mockClear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('calls vitestTest.fails when fails:true and actor is in the build list', async () => {
+        vi.stubEnv('ACTOR_BUILDS', JSON.stringify([ACTOR_BUILD]));
+
+        const { testStandbyActor } = await import('../../lib/lib.js');
+        testStandbyActor('my-actor', 'test name', noop, { fails: true });
+
+        expect(mockFails).toHaveBeenCalledOnce();
+        expect(mockRunIf).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
I would like to easily be able to invert a test. Look at the tests for what this actually does, or if you want a very AI generated description:

# Feature request: `fails` support in `testActor`

### The use case

Sometimes a scraper relies on a platform-side behaviour that can silently stop working (e.g. sending an undocumented API intent token that Facebook used to honour but no longer does). When that happens, a test that was asserting correct behaviour starts failing. The desired response is:

1. Acknowledge the regression — don't just delete or skip the test.
2. Keep a sentinel in CI that will **alert you if the behaviour resumes**, so you can re-enable the full assertion.

The current workaround is to manually invert every assertion with `.not`, add a prose comment explaining the inversion, and rename the test with a warning in the title. That's fragile and easy to misread.

### What Vitest already provides

Vitest has [`test.fails()`](https://vitest.dev/api/#test-fails). A test wrapped with it is expected to throw/fail. If it does fail, the suite reports it as **passed**. If it unexpectedly passes, the suite reports it as **failed** — exactly the sentinel behaviour we want. The symmetry with `test.skip()` / `test.todo()` makes the intent immediately legible to any Vitest user.

### Why it can't be used today

`testActor` is the only public entry point for platform tests, and internally it calls:

```main/node_modules/apify-test-tools/lib/lib.ts#L62-68
vitestTest.runIf(shouldRun)(name, options, async (context) => { … });
```

`vitestTest.runIf(condition)` returns a plain callable; you can't chain `.fails()` onto it. So consumers have no way to reach `vitestTest.fails.runIf(shouldRun)(…)` without bypassing `testActor` entirely — which means losing the build-pinning logic, the `run()` helper, and the `annotate` calls.

### Proposed change

Add an optional `fails` flag to `ActorTestOptions` (which already extends Vitest's `TestOptions`, so the pattern is familiar):

```/dev/null/types.ts#L1-10
export type ActorTestOptions = Omit<TestOptions, 'retry'> & {
    retry?: TestOptions['retry'];
    /**
     * Mark this test as expected to fail (wraps the underlying vitest test with `test.fails`).
     * The test passes as long as it keeps failing, and alerts you (by failing) if it starts passing.
     * Use this to keep a sentinel for known regressions without inverting assertions by hand.
     */
    fails?: boolean;
};
```

Then in `testActor` in `lib.ts`, swap the test function based on the flag:

```/dev/null/lib.ts#L1-10
const vitestTestFn = options.fails
    ? vitestTest.fails.runIf(shouldRun)
    : vitestTest.runIf(shouldRun);

vitestTestFn(name, options, async (context) => { … });
```

`vitestTest.fails` is itself a full `TestAPI` object (same shape as `vitestTest`), so `.runIf()` is available on it and the rest of the body is unchanged.

### What the call-site then looks like

```/dev/null/facebook-comments.test.ts#L1-20
testActor(
    ACTOR_ID,
    'Newest sorting works for posts that do not expose it in the UI',
    async ({ expect, run }) => {
        // … run actor …
        expect(results[0]?.profileName).toBe('Leif Andersson');
        expect(results[10]?.profileName).toBe('Pål Kvitberg');
    },
    { fails: true }, // Facebook stopped honouring REVERSE_CHRONOLOGICAL_UNFILTERED_INTENT_V1
                     // for posts that don't advertise it. Remove `fails` when it works again.
);
```

The assertions stay in their natural (positive) form, the inversion is expressed as a single structured option rather than spread across comments and `.not` calls, and any Vitest user reading the test immediately understands the intent.