### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -55,7 +55,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -77,20 +77,9 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
-            - name: Stage changes
-              id: stage
-              run: |
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore(release): Update changelog and package version [skip ci]'
+                  message: 'chore(release): Update changelog and package version [skip ci]'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -55,7 +55,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -55,7 +55,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -77,10 +77,20 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
+            - name: Stage changes
+              id: stage
+              run: |
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'chore(release): Update changelog and package version [skip ci]'
+                  commit-message: 'chore(release): Update changelog and package version [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.