### PR TITLE
fix(cli): GitHub action rerun ignores last validated commit and reruns all commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Running the testing library locally is useful when you only want to update the t
 If you don't need to change any source files and only iterate on /test code, you can skip steps 1-4. But if you want to test vs changed /src, you have to push that GitHub branch since it needs to build the Actors with that code.
 
 The main local flow is:
+
 1. Switch to a dummy branch that you will push and can later delete
 2. `npm i apify-test-tools@latest -D`
 3. Push your code (changes you want to test)
@@ -328,7 +329,7 @@ The main local flow is:
 
 If you want to test vs existing src code, you can skip this and instead construct the output JSON manually from existing builds only for the Actors you need to test.
 
-Requires `APIFY_TOKEN_<USERNAME>` for all Apify users that own your Actors (`e.g. `apify`, `compass`, `lukaskrivka` users). The username is derived from the actor name — uppercased with non-word chars replaced by `_` (e.g. Actor `john.doe/my-actor` needs `APIFY_TOKEN_JOHN_DOE`).
+Requires `APIFY_TOKEN_<USERNAME>` for all Apify users that own your Actors (e.g. `apify`, `compass`, `lukaskrivka` users). The username is derived from the actor name — uppercased with non-word chars replaced by `_` (e.g. Actor `john.doe/my-actor` needs `APIFY_TOKEN_JOHN_DOE`).
 
 ```bash
 APIFY_TOKEN_JOHN_DOE=<token> \

--- a/bin/git.ts
+++ b/bin/git.ts
@@ -8,10 +8,10 @@ const GIT_LOG_FORMAT = ['%H', '%aN<%aE>', '%aD', '%s'].join(GIT_FORMAT_SEPARATOR
  * Gets the list of changed files between the given commits (inclusive).
  */
 export const getChangedFiles = (commits: Commit[]) => {
-    // Happens e.g. on a workflow rerun where the base (last validated) commit is already the branch HEAD
+    // getCommits never returns an empty list (the rerun check returns all commits when the base commit
+    // is the branch HEAD, and an empty git range throws when parsing), so this signals a programmer error
     if (commits.length === 0) {
-        console.error('No commits to diff, returning no changed files');
-        return [];
+        throw new Error('Cannot get changed files: the commit list is empty. This should never happen.');
     }
 
     const changedFilesString = spawnCommandInGhWorkspace(
@@ -103,7 +103,7 @@ export const getCommits = ({ sourceBranch, targetBranch, baseCommit }: Config): 
     const headSha = commits[commits.length - 1]?.sha;
     if (baseCommitSha !== undefined && baseCommitSha === headSha) {
         console.error(
-            `Detected rerun with the same commit (maybe force push), running without validated commit ${baseCommitSha}`,
+            `Detected rerun with the same commit that we already validated. This usually means the user wants to rerun the Action from scratch, ignoring last validated commit ${baseCommitSha} and returning all commits`,
         );
         console.error(`Commits being returned: ${commits.map((c) => c.sha).join(', ')}`);
         return commits;

--- a/bin/git.ts
+++ b/bin/git.ts
@@ -98,6 +98,17 @@ export const getCommits = ({ sourceBranch, targetBranch, baseCommit }: Config): 
     const baseCommitSha = parseBaseCommit(baseCommit);
     const commits = fetchAllBranchCommits(sourceBranch, targetBranch);
 
+    // The last validated (base) commit being the branch HEAD means nothing new was pushed since the last
+    // validation — the dev reran the workflow (or force-pushed to the same state) to trigger a clean test
+    const headSha = commits[commits.length - 1]?.sha;
+    if (baseCommitSha !== undefined && baseCommitSha === headSha) {
+        console.error(
+            `Detected rerun with the same commit (maybe force push), running without validated commit ${baseCommitSha}`,
+        );
+        console.error(`Commits being returned: ${commits.map((c) => c.sha).join(', ')}`);
+        return commits;
+    }
+
     const baseCommitIndex = commits.findIndex((commit) => commit.sha === baseCommitSha);
 
     const hasBaseCommit = baseCommitIndex !== -1;

--- a/bin/git.ts
+++ b/bin/git.ts
@@ -8,6 +8,12 @@ const GIT_LOG_FORMAT = ['%H', '%aN<%aE>', '%aD', '%s'].join(GIT_FORMAT_SEPARATOR
  * Gets the list of changed files between the given commits (inclusive).
  */
 export const getChangedFiles = (commits: Commit[]) => {
+    // Happens e.g. on a workflow rerun where the base (last validated) commit is already the branch HEAD
+    if (commits.length === 0) {
+        console.error('No commits to diff, returning no changed files');
+        return [];
+    }
+
     const changedFilesString = spawnCommandInGhWorkspace(
         `git diff --name-only ${commits[0].sha}~..${commits[commits.length - 1].sha}`,
     );

--- a/test/unit/bin/git.test.ts
+++ b/test/unit/bin/git.test.ts
@@ -107,6 +107,15 @@ describe('getChangedFiles', () => {
         expect(gitCommandSpy).toHaveBeenCalledWith(`git diff --name-only ${firstSha}~..${lastSha}`);
     });
 
+    it('should return empty array without running git when there are no commits (e.g. rerun where base commit is branch HEAD)', () => {
+        // Act
+        const changedFiles = getChangedFiles([]);
+
+        // Assert
+        expect(changedFiles).toStrictEqual([]);
+        expect(gitCommandSpy).not.toHaveBeenCalled();
+    });
+
     it('should handle only one commit', () => {
         // Arrange
         const onlySha = '1'.repeat(40);

--- a/test/unit/bin/git.test.ts
+++ b/test/unit/bin/git.test.ts
@@ -63,6 +63,18 @@ describe('getCommits', () => {
         );
     });
 
+    it('should ignore the base commit and return all commits when it is the branch HEAD (rerun or force push)', () => {
+        // Act
+        const commits = getCommits({ sourceBranch, targetBranch, baseCommit: sha3 });
+
+        // Assert
+        expect(commits).toStrictEqual([
+            { sha: sha1, author: 'Author1', date: 'Date1', message: 'First Change On Feature' },
+            { sha: sha2, author: 'Author1', date: 'Date2', message: 'Second Change On Feature' },
+            { sha: sha3, author: 'Author1', date: 'Date3', message: 'Third Change On Feature' },
+        ]);
+    });
+
     it('should return all commits if base commit is not found', () => {
         // Act
         const commits = getCommits({ sourceBranch, targetBranch, baseCommit: 'a'.repeat(40) });

--- a/test/unit/bin/git.test.ts
+++ b/test/unit/bin/git.test.ts
@@ -119,12 +119,9 @@ describe('getChangedFiles', () => {
         expect(gitCommandSpy).toHaveBeenCalledWith(`git diff --name-only ${firstSha}~..${lastSha}`);
     });
 
-    it('should return empty array without running git when there are no commits (e.g. rerun where base commit is branch HEAD)', () => {
-        // Act
-        const changedFiles = getChangedFiles([]);
-
-        // Assert
-        expect(changedFiles).toStrictEqual([]);
+    it('should throw without running git when the commit list is empty', () => {
+        // Act & Assert
+        expect(() => getChangedFiles([])).toThrow('Cannot get changed files: the commit list is empty');
         expect(gitCommandSpy).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Closes https://github.com/apify/apify-test-tools/issues/91. This was a silent regression because we first broke last validated commit completely and when fixing forgot to handle reruns of successful actions.

[Tested here
](https://github.com/apify-store/testing-repo-for-github-actions/actions/runs/27298142240/job/80637497669)

## Summary
This PR adds logic to detect when a workflow is rerun with the same base commit (indicating no new changes were pushed) and returns all commits in that scenario, rather than filtering based on the base commit. It also adds validation to prevent empty commit lists from being processed.

## Key Changes
- **Rerun detection in `getCommits()`**: Added check to detect when the base commit SHA matches the branch HEAD, indicating a workflow rerun or force-push to the same state. When detected, all commits are returned and a descriptive error message is logged.
- **Empty commit list validation in `getChangedFiles()`**: Added guard clause to throw an error if an empty commit list is passed, preventing silent failures and signaling programmer errors.
- **Test coverage**: Added unit tests for both the rerun scenario and the empty commit list validation.
- **Documentation fix**: Minor formatting improvements in README.md (removed backtick formatting inconsistency).

## Implementation Details
- The rerun detection compares `baseCommitSha` with the HEAD commit SHA before attempting to find the base commit index
- Error messages provide context about why all commits are being returned and which commits are included
- The empty commit list check includes a comment explaining why this should never happen in normal operation

https://claude.ai/code/session_013oxUcETkRcWDXmy6uSEfaC