### PR TITLE
change: stop autobuilding Actors on circ_le account

### DIFF
--- a/bin/build.ts
+++ b/bin/build.ts
@@ -4,7 +4,6 @@ import { ApifyClient } from 'apify-client';
 import { ACTOR_SOURCE_TYPES } from '@apify/consts';
 
 import type { ActorConfig, BuildData } from './types.js';
-import { getEnvVar } from './utils.js';
 
 type BuildPrActorOptions = {
     buildTag?: string;
@@ -243,9 +242,7 @@ export const runBuilds = async ({
 }: RunBuildsOptions) => {
     const buildConfigs: BuildPrActorOptions[] = [];
 
-    const circleActors = isLatest ? await findCircleApifyManaged(actorConfigs) : [];
-
-    for (const { actorName, folder } of actorConfigs.concat(circleActors)) {
+    for (const { actorName, folder } of actorConfigs) {
         let versionNumber: string;
         let buildTag: string | undefined;
 
@@ -300,56 +297,4 @@ export const deleteOldBuilds = async (actorConfigs: ActorConfig[]) => {
     for (const { actorName } of actorConfigs) {
         await ApifyBuilder.fromActorName(actorName).deleteOldBuilds();
     }
-};
-
-/**
- * We will read all Actors in the circ_le account and build those that match by name pattern
- * There are many ways to approach this, a more robust one would be to have a map of Actors
- * which would allow to have more than one special user per Actor
- * But since that use-case might never be needed, I went with the simplest solution that doesn't require maintaining the map
- * NOTE: One issue is that if any Actor is renamed, we will not match it in the circ_le account nor throw any error
- */
-const findCircleApifyManaged = async (actorConfigs: ActorConfig[]): Promise<ActorConfig[]> => {
-    // This token is hardcoded in the runner Actor, locally you have to inject it
-    const client = new ApifyClient({ token: getEnvVar('APIFY_TOKEN_CIRC_LE') });
-
-    const { items: circleActors } = await client.actors().list();
-
-    const actorsToBuild = circleActors
-        .map<ActorConfig | undefined>((circleActor) => {
-            // They prefix all with apify-managed---, I communicated with Jacques to keep doing that
-            let actorConfigFound = actorConfigs.find(
-                (actorConfig) =>
-                    circleActor.name.replace('apify-managed---', '') === actorConfig.actorName.split('/')[1],
-            );
-
-            // Hack for bad naming of circ_le/apify-managed-google-search, we don't want to rename now to break customers
-            if (!actorConfigFound && circleActor.name === 'apify-managed-google-search') {
-                actorConfigFound = actorConfigs.find(
-                    (actorConfig) => actorConfig.actorName.split('/')[1] === 'google-search-scraper',
-                );
-            }
-
-            if (actorConfigFound) {
-                return {
-                    // We point the circle Actor to the repo folder
-                    actorName: `${circleActor.username}/${circleActor.name}`,
-                    folder: actorConfigFound.folder,
-                    isStandalone: actorConfigFound.isStandalone,
-                };
-            }
-            return undefined;
-        })
-        .filter((config) => config !== undefined);
-
-    console.error(
-        `Found ${actorsToBuild.length} circ_le actors that match Actors we built out of total ${circleActors.length} circ_le actors`,
-    );
-    console.error(`All circ_le actors: ${circleActors.map((actor) => actor.name).join(', ')}`);
-    console.error(`circ_le Actors to build: ${actorsToBuild.map((actor) => actor.actorName).join(', ')}`);
-
-    if (actorsToBuild.length === 0) {
-        console.error('No circ_le actors to build');
-    }
-    return actorsToBuild;
 };


### PR DESCRIPTION
## Summary
This PR removes the functionality that automatically discovers and builds actors from the `circ_le` Apify account during the build process.

## Key Changes
- Removed the `findCircleApifyManaged()` function that queried the `circ_le` account for actors matching naming patterns
- Removed the conditional logic in `runBuilds()` that called `findCircleApifyManaged()` when `isLatest` was true
- Removed the unused import of `getEnvVar` utility function
- Simplified the build loop to only process actors from the provided `actorConfigs` parameter

## Implementation Details
The removed `findCircleApifyManaged()` function previously:
- Connected to the `circ_le` Apify account using a hardcoded token
- Matched actors by name pattern (removing `apify-managed---` prefix)
- Included a special case hack for the `google-search-scraper` actor
- Logged detailed information about discovered and matched actors

This change simplifies the build process by removing the special handling for externally-managed actors, making the build configuration more explicit and maintainable.

https://claude.ai/code/session_018xNhRQfGxV6yoivYhVjvbK