### PR TITLE
chore: fix deploy version parsing in pre-release script for npm 12 compatibility

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -19,7 +19,9 @@ writeFileSync(PKG_JSON_PATH, `${JSON.stringify(pkgJson, null, 2)}\n`);
 
 function addBetaSuffixToVersion(version) {
     const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
-    const versions = JSON.parse(versionString);
+    // Normalize npm's output: npm 12 wraps the versions in an extra array ([[...]]),
+    // and npm returns a bare string for packages with a single published version.
+    const versions = [JSON.parse(versionString)].flat(Infinity).filter((v) => typeof v === 'string');
 
     if (versions.some((v) => v === version)) {
         console.error(


### PR DESCRIPTION
## Summary
Updated the version parsing logic in the pre-release script to handle inconsistent output formats from different npm versions.

## Key Changes
- Modified `addBetaSuffixToVersion()` to normalize npm's version output across different npm versions
- Added handling for npm 12's double-wrapped array format (`[[...]]`)
- Added handling for single-version packages that return a bare string instead of an array
- Implemented a robust parsing strategy using `flat(Infinity)` and type filtering to extract version strings

## Implementation Details
The npm CLI returns version information in different formats depending on the npm version and package state:
- npm 12 wraps the versions array in an extra array layer
- Packages with only one published version may return a bare string instead of an array

The fix uses `[JSON.parse(versionString)].flat(Infinity).filter((v) => typeof v === 'string')` to normalize all these cases into a consistent array of version strings, ensuring the script works reliably across npm versions.

https://claude.ai/code/session_01S3skLbP3YnDAYp124zzaS5