### PR TITLE
fix: increase default dataset sync timeout

### DIFF
--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -16,3 +16,10 @@ export const TO_FINISH_WITH_OPTIONS: ToFinishWithOptionsWithDefaults = {
  * Both the test runs and the vitest test specs should finish in this time - 1 hour
  */
 export const DEFAULT_TEST_RUN_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Delay before checking the dataset and statistics after a run finishes to resolve eventual consistency.
+ * - This value should ensure that the dataset and statistics are fully updated before any assertions are made.
+ * - Super rarely the platform is still not synced even after 10s, so 20s should be sufficient practically always.
+ */
+export const DEFAULT_DATASET_SYNC_DELAY_MS = 20 * 1000; // 20 seconds

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -22,4 +22,4 @@ export const DEFAULT_TEST_RUN_DURATION_MS = 60 * 60 * 1000; // 1 hour
  * - This value should ensure that the dataset and statistics are fully updated before any assertions are made.
  * - Super rarely the platform is still not synced even after 10s, so 20s should be sufficient practically always.
  */
-export const DEFAULT_DATASET_SYNC_DELAY_MS = 20 * 1000; // 20 seconds
+export const DATASET_SYNC_DELAY_MS = 20 * 1000; // 20 seconds

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -3,7 +3,7 @@ import { ApifyClient } from 'apify-client';
 import type { SuiteFactory, TestContext, TestFunction } from 'vitest';
 import { describe as vitestDescribe, ExpectStatic, test as vitestTest } from 'vitest';
 
-import { DEFAULT_DATASET_SYNC_DELAY_MS, DEFAULT_TEST_RUN_DURATION_MS } from './consts.js';
+import { DATASET_SYNC_DELAY_MS, DEFAULT_TEST_RUN_DURATION_MS } from './consts.js';
 import { extendExpect } from './extend-expect.js';
 import { RunTestResult } from './run-test-result.js';
 import type { ActorBuild, ActorTestOptions, RunOptions } from './types.js';
@@ -61,7 +61,6 @@ export const testActor = <T>(
         ...DEFAULT_TEST_ACTOR_OPTIONS,
         ...testOptions,
     };
-    const { datasetSyncDelayMs = DEFAULT_DATASET_SYNC_DELAY_MS } = options;
 
     const name = `${actorName}: ${testName}`;
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorName);
@@ -69,7 +68,7 @@ export const testActor = <T>(
         const { expect, ...rest } = context;
         await fn({
             expect: extendExpect(expect),
-            run: createStartRunFn(actorName, context, { datasetSyncDelayMs }),
+            run: createStartRunFn(actorName, context),
             ...rest,
         });
     });
@@ -249,12 +248,7 @@ const createStandbyTask = async (actorNameOrId: string, buildNumber?: string): P
     }
 };
 
-const createStartRunFn = <T>(
-    actorNameOrId: string,
-    testContext: TestContext,
-    testOptions: { datasetSyncDelayMs: number },
-) => {
-    const { datasetSyncDelayMs } = testOptions;
+const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) => {
     const { annotate, task } = testContext;
     const actorConfig = config.get(actorNameOrId);
     const build = actorConfig?.buildNumber;
@@ -288,7 +282,7 @@ const createStartRunFn = <T>(
         };
 
         // waiting for dataset and statistics to sync, the Apify platform is only eventually consistent.
-        await sleep(datasetSyncDelayMs);
+        await sleep(DATASET_SYNC_DELAY_MS);
 
         return new RunTestResult(apifyClient, run);
     };

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -3,7 +3,7 @@ import { ApifyClient } from 'apify-client';
 import type { SuiteFactory, TestContext, TestFunction } from 'vitest';
 import { describe as vitestDescribe, ExpectStatic, test as vitestTest } from 'vitest';
 
-import { DEFAULT_TEST_RUN_DURATION_MS } from './consts.js';
+import { DEFAULT_DATASET_SYNC_DELAY_MS, DEFAULT_TEST_RUN_DURATION_MS } from './consts.js';
 import { extendExpect } from './extend-expect.js';
 import { RunTestResult } from './run-test-result.js';
 import type { ActorBuild, ActorTestOptions, RunOptions } from './types.js';
@@ -61,13 +61,15 @@ export const testActor = <T>(
         ...DEFAULT_TEST_ACTOR_OPTIONS,
         ...testOptions,
     };
+    const { datasetSyncDelayMs = DEFAULT_DATASET_SYNC_DELAY_MS } = options;
+
     const name = `${actorName}: ${testName}`;
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorName);
     vitestTest.runIf(shouldRun)(name, options, async <TYPE extends TestContext>(context: TYPE) => {
         const { expect, ...rest } = context;
         await fn({
             expect: extendExpect(expect),
-            run: createStartRunFn(actorName, context),
+            run: createStartRunFn(actorName, context, { datasetSyncDelayMs }),
             ...rest,
         });
     });
@@ -247,7 +249,12 @@ const createStandbyTask = async (actorNameOrId: string, buildNumber?: string): P
     }
 };
 
-const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) => {
+const createStartRunFn = <T>(
+    actorNameOrId: string,
+    testContext: TestContext,
+    testOptions: { datasetSyncDelayMs: number },
+) => {
+    const { datasetSyncDelayMs } = testOptions;
     const { annotate, task } = testContext;
     const actorConfig = config.get(actorNameOrId);
     const build = actorConfig?.buildNumber;
@@ -280,8 +287,8 @@ const createStartRunFn = <T>(actorNameOrId: string, testContext: TestContext) =>
             actorName: actorNameOrId,
         };
 
-        // waiting for datasetItemCount and chargedEventCounts to sync
-        await sleep(10_000);
+        // waiting for dataset and statistics to sync, the Apify platform is only eventually consistent.
+        await sleep(datasetSyncDelayMs);
 
         return new RunTestResult(apifyClient, run);
     };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -144,13 +144,6 @@ export type ActorTestOptions = Omit<TestOptions, 'retry' | 'timeout'> & {
      * @default 60 * 60 * 1000 // 1 hour
      */
     timeout?: ActorCallOptions['timeout'];
-    /**
-     * Delay in milliseconds before checking the dataset and statistics after a run finishes.
-     * - Useful for ensuring that the dataset is fully synchronized, the Apify platform is only eventually consistent.
-     *
-     * @default 20_000 // 20 seconds
-     */
-    datasetSyncDelayMs?: number;
 };
 
 declare module 'vitest' {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -144,6 +144,13 @@ export type ActorTestOptions = Omit<TestOptions, 'retry' | 'timeout'> & {
      * @default 60 * 60 * 1000 // 1 hour
      */
     timeout?: ActorCallOptions['timeout'];
+    /**
+     * Delay in milliseconds before checking the dataset and statistics after a run finishes.
+     * - Useful for ensuring that the dataset is fully synchronized, the Apify platform is only eventually consistent.
+     *
+     * @default 20_000 // 20 seconds
+     */
+    datasetSyncDelayMs?: number;
 };
 
 declare module 'vitest' {


### PR DESCRIPTION
Turns out that the previous ten seconds are also not enough in some rare cases. Increasing to 20s should fix this.

I've decided to also make this option modifiable by the user, but I'm not quite sure about passing it down the arguments of the functions like this. Let me know your thoughts. 

---
Fixes https://github.com/apify-store/amazon/issues/687