### PR TITLE
refactor: Remove need for RUN_PLATFORM_TESTS env var, rely on TESTER_APIFY_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,14 +439,13 @@ Since you already scoped the build to just the Actor(s) you care about, point vi
 
 #### 5. Run tests against the builds
 
-Pass the build output as `ACTOR_BUILDS` and provide `TESTER_APIFY_TOKEN`. The token can point to your own account (if you have enough memory) or you can use the testing account (xRGg9iAfJSymqartk).
+Pass the build output as `ACTOR_BUILDS` and provide `TESTER_APIFY_TOKEN`. The token can point to your own account (if you have enough memory) or you can use the testing account (xRGg9iAfJSymqartk). Platform test suites are skipped unless `TESTER_APIFY_TOKEN` is set, so regular unit test runs stay unaffected.
 
 If you want to run only certain tests, change the `test/platform` to be more specific.
 
 ```bash
 ACTOR_BUILDS='<JSON output from build command>' \
 TESTER_APIFY_TOKEN=<token> \
-RUN_PLATFORM_TESTS=1 \
   npx vitest --run --maxConcurrency 20 --fileParallelism=true --maxWorkers 100 test/platform
 ```
 
@@ -463,7 +462,6 @@ BUILDS=$(APIFY_TOKEN_JOHN_DOE=apify_api_xxx \
 # Run tests with the builds
 ACTOR_BUILDS="$BUILDS" \
 TESTER_APIFY_TOKEN=apify_api_yyy \
-RUN_PLATFORM_TESTS=1 \
   npx vitest --run --maxConcurrency 20 --fileParallelism=true --maxWorkers 100 test/platform
 ```
 

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -43,6 +43,9 @@ const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
 
 /**
  * Platform tests only run when `TESTER_APIFY_TOKEN` is provided, since they need the platform to run against.
+ *
+ * `RUN_ALL_PLATFORM_TESTS` is needed for periodic tests, where there is no `ACTOR_BUILDS` env var to match
+ * the tests against - without it, every `testActor` would be filtered out as an actor we didn't build.
  */
 export const describe = (name: string, fn?: SuiteFactory<object>, options: ActorTestOptions = DEFAULT_TEST_OPTIONS) => {
     vitestDescribe.runIf(!!TESTER_APIFY_TOKEN || !!RUN_ALL_PLATFORM_TESTS)(name, options, fn);

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -42,10 +42,10 @@ const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
 };
 
 /**
- * Platform tests only run when `TESTER_APIFY_TOKEN` is provided, since they need the platform to run against.
+ * Platform tests need `TESTER_APIFY_TOKEN` to talk to the platform, so without it we skip them altogether.
  *
- * `RUN_ALL_PLATFORM_TESTS` is needed for periodic tests, where there is no `ACTOR_BUILDS` env var to match
- * the tests against - without it, every `testActor` would be filtered out as an actor we didn't build.
+ * `RUN_ALL_PLATFORM_TESTS` enables them too because locally we can test against a hardcoded `runId`,
+ * which doesn't need the tester token.
  */
 export const describe = (name: string, fn?: SuiteFactory<object>, options: ActorTestOptions = DEFAULT_TEST_OPTIONS) => {
     vitestDescribe.runIf(!!TESTER_APIFY_TOKEN || !!RUN_ALL_PLATFORM_TESTS)(name, options, fn);
@@ -71,6 +71,8 @@ export const testActor = <T>(
         ...testOptions,
     };
     const name = `${actorId}: ${testName}`;
+    // `RUN_ALL_PLATFORM_TESTS` is needed for the scheduled tests, which have no `ACTOR_BUILDS` to match the
+    // tests against - without it, every test would be filtered out as an actor we didn't build.
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorId);
     vitestTest.runIf(shouldRun)(name, options, async <TYPE extends TestContext>(context: TYPE) => {
         const { expect, ...rest } = context;
@@ -103,6 +105,8 @@ export const testStandbyActor = <I = any, O = any>(
         ...testOptions,
     };
     const name = `${actorId}: ${testName}`;
+    // `RUN_ALL_PLATFORM_TESTS` is needed for the scheduled tests, which have no `ACTOR_BUILDS` to match the
+    // tests against - without it, every test would be filtered out as an actor we didn't build.
     const shouldRun = !!RUN_ALL_PLATFORM_TESTS || config.has(actorId);
 
     vitestTest.runIf(shouldRun)(name, options, async <T extends TestContext>(context: T) => {

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -31,7 +31,7 @@ const config = actorBuilds.reduce<Map<string, ActorBuild>>((map, cfg) => {
 
 export { ExpectStatic };
 
-const { TESTER_APIFY_TOKEN, RUN_PLATFORM_TESTS, RUN_ALL_PLATFORM_TESTS } = process.env;
+const { TESTER_APIFY_TOKEN, RUN_ALL_PLATFORM_TESTS } = process.env;
 const apifyClient = new ApifyClient({ token: TESTER_APIFY_TOKEN });
 
 const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
@@ -41,8 +41,11 @@ const DEFAULT_TEST_OPTIONS: ActorTestOptions = {
     timeout: DEFAULT_TEST_RUN_DURATION_MS,
 };
 
+/**
+ * Platform tests only run when `TESTER_APIFY_TOKEN` is provided, since they need the platform to run against.
+ */
 export const describe = (name: string, fn?: SuiteFactory<object>, options: ActorTestOptions = DEFAULT_TEST_OPTIONS) => {
-    vitestDescribe.runIf(!!RUN_PLATFORM_TESTS || !!RUN_ALL_PLATFORM_TESTS)(name, options, fn);
+    vitestDescribe.runIf(!!TESTER_APIFY_TOKEN || !!RUN_ALL_PLATFORM_TESTS)(name, options, fn);
 };
 
 const DEFAULT_TEST_ACTOR_OPTIONS: ActorTestOptions = {


### PR DESCRIPTION
Closes https://github.com/apify/apify-test-tools/issues/121

Shouldn't be breaking for anyone, only if you would configure `RUN_PLATFORM_TESTS` locally while also passing `TESTER_APIFY_TOKEN`, unlikely

## Summary
Removed the `RUN_PLATFORM_TESTS` environment variable and simplified the platform test gating logic to rely solely on the presence of `TESTER_APIFY_TOKEN`. This reduces configuration complexity while maintaining the same functionality.

## Key Changes
- Removed `RUN_PLATFORM_TESTS` from environment variable destructuring in `lib/lib.ts`
- Updated the `describe` function's `runIf` condition to check `!!TESTER_APIFY_TOKEN || !!RUN_ALL_PLATFORM_TESTS` instead of `!!RUN_PLATFORM_TESTS || !!RUN_ALL_PLATFORM_TESTS`
- Added comprehensive documentation explaining when platform tests run and why `RUN_ALL_PLATFORM_TESTS` is needed for periodic tests
- Updated README.md to remove `RUN_PLATFORM_TESTS=1` from all example commands
- Added clarification that platform test suites are automatically skipped unless `TESTER_APIFY_TOKEN` is set, keeping regular unit test runs unaffected

## Implementation Details
The change leverages the fact that `TESTER_APIFY_TOKEN` is already a required dependency for platform tests (needed to instantiate the ApifyClient). By using its presence as the gating condition, we eliminate redundant configuration while maintaining backward compatibility with the `RUN_ALL_PLATFORM_TESTS` flag for periodic test scenarios where no `ACTOR_BUILDS` environment variable is available.

https://claude.ai/code/session_01JSd2mJ6ZFg8cf7dRg4nTQg